### PR TITLE
remove outdated UA contact detail

### DIFF
--- a/src/state/queries/constellation.ts
+++ b/src/state/queries/constellation.ts
@@ -22,7 +22,7 @@ type Collection =
 
 const headers = new Headers({
   Accept: 'application/json',
-  'User-Agent': 'blacksky.community (contact @aviva.gay)',
+  'User-Agent': 'blacksky.community',
 })
 
 const makeReqUrl = (


### PR DESCRIPTION
...since this still has Aviva's contact info from her work on custom verifiers 💜

(note: the constellation docs request that you put some contact info in the UA, but I had server apps in mind when I wrote that -- for client-side apps and especially web, it's not necessary)