### PR TITLE
UX Issues with profile privacy, unfollows, mutes

### DIFF
--- a/patches/@atproto+api+0.16.7.patch
+++ b/patches/@atproto+api+0.16.7.patch
@@ -1,12 +1,14 @@
 diff --git a/node_modules/@atproto/api/dist/moderation/decision.js b/node_modules/@atproto/api/dist/moderation/decision.js
-index aaac177..d27c0be 100644
+index 6dd9d4d..59df896 100644
 --- a/node_modules/@atproto/api/dist/moderation/decision.js
 +++ b/node_modules/@atproto/api/dist/moderation/decision.js
-@@ -67,6 +67,8 @@ class ModerationDecision {
+@@ -67,6 +67,10 @@ class ModerationDecision {
      ui(context) {
          const ui = new ui_1.ModerationUI();
          for (const cause of this.causes) {
-+            if (cause?.label?.val === '!no-unauthenticated') continue;
++            // Skip !no-unauthenticated label only if user is authenticated
++            // If userDid is present in opts, user is logged in
++            if (cause?.label?.val === '!no-unauthenticated' && this.opts?.userDid) continue;
 +
              if (cause.type === 'blocking' ||
                  cause.type === 'blocked-by' ||

--- a/src/state/queries/useQueryWithFallback.ts
+++ b/src/state/queries/useQueryWithFallback.ts
@@ -11,6 +11,7 @@ import {
   type UseQueryResult,
 } from '@tanstack/react-query'
 
+import {useSession} from '#/state/session'
 import {
   buildSyntheticFeedPage,
   buildSyntheticPostView,
@@ -109,6 +110,7 @@ export function useQuery<TData = unknown, TError = Error>(
   } = options
 
   const queryClient = useQueryClient()
+  const {hasSession} = useSession()
 
   // Wrap the original queryFn with fallback logic
   const wrappedQueryFn: typeof queryFn = async context => {
@@ -120,6 +122,15 @@ export function useQuery<TData = unknown, TError = Error>(
     } catch (error: any) {
       // If fallback is disabled or this isn't an AppView error, re-throw
       if (!enableFallback || !isAppViewError(error)) {
+        throw error
+      }
+
+      // SECURITY: Do NOT trigger fallback for logged-out users
+      // This prevents bypassing AppView access controls like logged-out visibility settings
+      if (!hasSession) {
+        console.log(
+          '[Fallback] Skipping fallback for logged-out user (respecting access controls)',
+        )
         throw error
       }
 
@@ -210,6 +221,7 @@ export function useInfiniteQuery<
   } = options
 
   const queryClient = useQueryClient()
+  const {hasSession} = useSession()
 
   // Wrap the original queryFn with fallback logic
   const wrappedQueryFn = async (
@@ -223,6 +235,15 @@ export function useInfiniteQuery<
     } catch (error: any) {
       // If fallback is disabled or this isn't an AppView error, re-throw
       if (!enableFallback || !isAppViewError(error)) {
+        throw error
+      }
+
+      // SECURITY: Do NOT trigger fallback for logged-out users
+      // This prevents bypassing AppView access controls like logged-out visibility settings
+      if (!hasSession) {
+        console.log(
+          '[Fallback] Skipping fallback for logged-out user (respecting access controls)',
+        )
         throw error
       }
 


### PR DESCRIPTION
# UX Fixes

This Is a PR to fix issues reported by several users from support.

      1. User sets "logged-out visibility: disabled" which adds the !no-unauthenticated self-label to their profile
      2. The AppView returns the profile data WITH the label
      3. The patched @atproto/api library was always skipping this label in moderation checks (line 70 in decision.js)
      4. So the moderation system never created a "blur" for it
      5. The ScreenHider component never triggered
      6. Profile was visible!
    
    fallback mechanism only works with logged users. and checks the label
    for privacy no-authenticated label.
    
    This resolves the issue folkloringjamaica.blacksky.app was experiencing
    
    @ind3fatigable.online was experiencing mute and follow issues which
    surrounded cache invalidation issues that was resolved.


# Test Evaluation


Test 1: Unfollow Persistence
    
      1. Follow a user (if not already following)
      2. Unfollow them by clicking the "Following" button
      3. ✅ Expected: Button immediately changes to "Follow"
      4. Wait 1-2 seconds (for the AppView indexing lag compensation to kick in)
      5. Refresh the page (hard refresh or navigate away and back)
      6. ✅ Expected: Still shows "Follow" button (unfollow persisted)
      7. Bonus: Check that their posts no longer appear in your Following feed
    
      Test 2: Follow/Unfollow Multiple Times Rapidly
    
      1. Follow a user
      2. Immediately unfollow them
      3. Repeat this 2-3 times quickly (stress test the mutation queue)
      4. Refresh the page
      5. ✅ Expected: Final state matches what you see (if you ended on "Follow", it stays "Follow" after refresh)
    
      Test 3: Mute Persistence
    
      1. Navigate to a user's profile
      2. Mute them (via the three-dot menu → Mute)
      3. ✅ Expected: Profile should indicate they're muted
      4. Refresh the page
      5. ✅ Expected: Still shows as muted
      6. Go to your home feed
      7. ✅ Expected: Their posts should no longer appear in your feed
    
      Test 4: Unmute Persistence
    
      1. Unmute a previously muted user
      2. Refresh the page
      3. ✅ Expected: No longer shows as muted
      4. Check your feed
      5. ✅ Expected: Their posts can now appear again
    
      Test 5: Cross-Tab Consistency (Advanced)
    
      1. Open the same profile in two browser tabs
      2. In Tab 1: Unfollow the user
      3. In Tab 2: Refresh the page after 1-2 seconds
      4. ✅ Expected: Tab 2 should now show "Follow" button (cache was invalidated)
    
      What Was Fixed:
    
      - Before: Cache wasn't being invalidated, so refreshing would show stale data from cache
      - After:
        - Immediate cache invalidation on mutation success
        - 500ms delayed refetch to handle AppView indexing lag
        - Comprehensive invalidation of profile, feed, and related caches