### PR TITLE
OAuth error messages + session lifecycle telemetry

### DIFF
--- a/src/analytics/metrics/types.ts
+++ b/src/analytics/metrics/types.ts
@@ -35,6 +35,63 @@ export type Events = {
       | 'AgeAssuranceNoAccessScreen'
     scope: 'current' | 'every'
   }
+  // OAuth session lifecycle. These are silent client-side events used to
+  // diagnose unexpected sign-outs (refresh races, IndexedDB eviction, DPoP
+  // skew, etc.). `account:loggedOut` is reserved for user-initiated logouts.
+  'oauth:sessionDeleted': {
+    // Reason the underlying OAuth client deleted the local session.
+    // Common values map to oauth-client/session-getter causes:
+    //   'session_deleted_by_another_process' — refresh race / cross-tab
+    //   'invalid_grant'                      — refresh token rejected
+    //   'database_closed'                    — IndexedDB unavailable / evicted
+    //   'unknown'                            — unmapped cause
+    cause: string
+    // Truncated error message for further triage in OpenSearch.
+    message?: string
+  }
+  'oauth:sessionRefreshed': {}
+  // Fired when a refresh round-trip to /oauth/token fails for any reason —
+  // network blocked, timeout, 5xx, server-side rejection. The session may or
+  // may not survive (a 400 invalid_grant will additionally fire
+  // oauth:sessionDeleted; a network blip will not).
+  'oauth:refreshFailed': {
+    triggerContext: 'background' | 'debugButton'
+    errorCategory:
+      | 'sessionDeleted'
+      | 'sessionExpired'
+      | 'invalidGrant'
+      | 'databaseClosed'
+      | 'dpopSkew'
+      | 'dpopOther'
+      | 'refreshExhausted'
+      | 'subMismatch'
+      | 'timeout'
+      | 'network'
+      | 'serverError'
+      | 'unknown'
+    // Truncated for triage in OpenSearch / postgres.
+    message?: string
+    // HTTP status when the failure was a non-2xx response (vs. a thrown fetch).
+    httpStatus?: number
+  }
+  'oauth:sessionResumeFailed': {
+    // Where in the app the resume attempt happened.
+    logContext: 'AppBoot' | 'ChooseAccountForm' | 'SwitchAccount'
+    // Coarse error category derived from the thrown error string.
+    errorCategory:
+      | 'sessionDeleted'
+      | 'sessionExpired'
+      | 'invalidGrant'
+      | 'databaseClosed'
+      | 'dpopSkew'
+      | 'dpopOther'
+      | 'refreshExhausted'
+      | 'subMismatch'
+      | 'timeout'
+      | 'network'
+      | 'unknown'
+    message?: string
+  }
   'notifications:openApp': {
     reason: NotificationReason
     causedBoot: boolean

--- a/src/lib/strings/errors.ts
+++ b/src/lib/strings/errors.ts
@@ -39,6 +39,34 @@ export function cleanError(str: any): string {
   ) {
     return t`This feature is not available with your current session. Please manage your account through your hosting provider's website, or sign out and sign back in to refresh your permissions.`
   }
+  if (
+    str.includes('session was deleted by another process') ||
+    str.includes('No refresh token available') ||
+    str.includes('The session was revoked')
+  ) {
+    return t`Your session has expired. Please sign in again.`
+  }
+  if (
+    str.includes('Database closed') ||
+    str.includes('Database has been disposed')
+  ) {
+    return t`Session storage is unavailable. Please sign in again.`
+  }
+  if (str.includes('invalid_dpop_proof') && str.includes('iat claim')) {
+    return t`Your device clock appears to be incorrect. Please check your system time settings and try again.`
+  }
+  if (str.includes('invalid_dpop_proof')) {
+    return t`Authentication error. Please try signing in again.`
+  }
+  if (str.includes('Session resume timed out')) {
+    return t`Sign in is taking too long. Please try again.`
+  }
+  if (
+    str.includes('Token set sub mismatch') ||
+    str.includes('Stored session sub mismatch')
+  ) {
+    return t`Session data is corrupted. Please sign in again.`
+  }
   if (str.includes('Account has been suspended')) {
     return t`Account has been suspended`
   }

--- a/src/screens/Login/ChooseAccountForm.tsx
+++ b/src/screens/Login/ChooseAccountForm.tsx
@@ -3,6 +3,7 @@ import {View} from 'react-native'
 import {msg, Trans} from '@lingui/macro'
 import {useLingui} from '@lingui/react'
 
+import {cleanError} from '#/lib/strings/errors'
 import {logger} from '#/logger'
 import {type SessionAccount, useSession, useSessionApi} from '#/state/session'
 import {useLoggedOutViewControls} from '#/state/shell/logged-out'
@@ -64,7 +65,8 @@ export const ChooseAccountForm = ({
         logger.error('choose account: initSession failed', {
           message: e.message,
         })
-        Toast.show(_(msg`Sign in failed. Please try again.`))
+        const errMsg = cleanError(e.message || e.toString())
+        Toast.show(errMsg || _(msg`Sign in failed. Please try again.`))
         // Move to login form.
         onSelectAccount(account)
       } finally {

--- a/src/screens/Settings/Settings.tsx
+++ b/src/screens/Settings/Settings.tsx
@@ -23,8 +23,11 @@ import {clearStorage} from '#/state/persisted'
 import {useModerationOpts} from '#/state/preferences/moderation-opts'
 import {useDeleteActorDeclaration} from '#/state/queries/messages/actor-declaration'
 import {useProfileQuery, useProfilesQuery} from '#/state/queries/profile'
-import {useAgent} from '#/state/session'
 import {type SessionAccount, useSession, useSessionApi} from '#/state/session'
+import {
+  getWebOAuthClient,
+  markNextRefreshContext,
+} from '#/state/session/oauth-web-client'
 import {useOnboardingDispatch} from '#/state/shell'
 import {useLoggedOutViewControls} from '#/state/shell/logged-out'
 import {useCloseAllActiveElements} from '#/state/util'
@@ -33,7 +36,6 @@ import {UserAvatar} from '#/view/com/util/UserAvatar'
 import * as SettingsList from '#/screens/Settings/components/SettingsList'
 import {atoms as a, platform, tokens, useBreakpoints, useTheme} from '#/alf'
 import {AvatarStackWithFetch} from '#/components/AvatarStack'
-import {Button, ButtonText} from '#/components/Button'
 import {useIsFindContactsFeatureEnabledBasedOnGeolocation} from '#/components/contacts/country-allowlist'
 import {useDialogControl} from '#/components/Dialog'
 import {SwitchAccountDialog} from '#/components/dialogs/SwitchAccount'
@@ -60,6 +62,7 @@ import * as Layout from '#/components/Layout'
 import {Loader} from '#/components/Loader'
 import * as Menu from '#/components/Menu'
 import * as Prompt from '#/components/Prompt'
+import * as ToastV2 from '#/components/Toast'
 import {Text} from '#/components/Typography'
 import {useFullVerificationState} from '#/components/verification'
 import {
@@ -68,7 +71,6 @@ import {
 } from '#/components/verification/VerificationCheckButton'
 import {useAnalytics} from '#/analytics'
 import {IS_INTERNAL, IS_IOS, IS_NATIVE} from '#/env'
-import {device, useStorage} from '#/storage'
 import {useActivitySubscriptionsNudged} from '#/storage/hooks/activity-subscriptions-nudged'
 
 type Props = NativeStackScreenProps<CommonNavigatorParams, 'Settings'>
@@ -379,7 +381,7 @@ function ProfilePreview({
 
 function DevOptions() {
   const {_} = useLingui()
-  const agent = useAgent()
+  const {currentAccount} = useSession()
   const onboardingDispatch = useOnboardingDispatch()
   const navigation = useNavigation<NavigationProp>()
   const {mutate: deleteChatDeclarationRecord} = useDeleteActorDeclaration()
@@ -462,6 +464,30 @@ function DevOptions() {
         label={_(msg`Open moderation debug page`)}>
         <SettingsList.ItemText>
           <Trans>Debug Moderation</Trans>
+        </SettingsList.ItemText>
+      </SettingsList.PressableItem>
+      <SettingsList.PressableItem
+        onPress={async () => {
+          if (!currentAccount?.isOauthSession) {
+            ToastV2.show(_(msg`Current account is not an OAuth session`), {
+              type: 'warning',
+            })
+            return
+          }
+          markNextRefreshContext('debugButton')
+          try {
+            await getWebOAuthClient().restore(currentAccount.did, true)
+            ToastV2.show(_(msg`OAuth refresh succeeded`), {type: 'success'})
+          } catch (e) {
+            const msgText = e instanceof Error ? e.message : String(e)
+            ToastV2.show(_(msg`OAuth refresh failed: ${msgText}`), {
+              type: 'error',
+            })
+          }
+        }}
+        label={_(msg`Force OAuth token refresh`)}>
+        <SettingsList.ItemText>
+          <Trans>Force OAuth token refresh</Trans>
         </SettingsList.ItemText>
       </SettingsList.PressableItem>
       <SettingsList.PressableItem

--- a/src/state/session/index.tsx
+++ b/src/state/session/index.tsx
@@ -29,6 +29,7 @@ import {
   oauthCreateAgent,
   oauthResumeSession,
 } from './oauth-agent'
+import {categorizeOauthError, setOauthTelemetrySink} from './oauth-telemetry'
 import {type Action, getInitialState, reducer, type State} from './reducer'
 export {isSignupQueued} from './util'
 import {addSessionDebugLog} from './logging'
@@ -263,7 +264,16 @@ export function Provider({children}: React.PropsWithChildren<{}>) {
         account: persisted.PersistedAccount
       }
       if (storedAccount.isOauthSession) {
-        agentAccount = await oauthResumeSession(storedAccount)
+        try {
+          agentAccount = await oauthResumeSession(storedAccount)
+        } catch (e) {
+          ax.metric('oauth:sessionResumeFailed', {
+            logContext: isSwitchingAccounts ? 'SwitchAccount' : 'AppBoot',
+            errorCategory: categorizeOauthError(e),
+            message: (e instanceof Error ? e.message : String(e)).slice(0, 200),
+          })
+          throw e
+        }
       } else {
         agentAccount = await createAgentAndResume(
           storedAccount,
@@ -322,6 +332,13 @@ export function Provider({children}: React.PropsWithChildren<{}>) {
     },
     [store, cancelPendingTask],
   )
+  useEffect(() => {
+    setOauthTelemetrySink(event => {
+      ax.metric(event.type, event.payload)
+    })
+    return () => setOauthTelemetrySink(null)
+  }, [ax])
+
   useEffect(() => {
     return persisted.onUpdate('session', nextSession => {
       const synced = nextSession
@@ -385,6 +402,7 @@ export function Provider({children}: React.PropsWithChildren<{}>) {
   )
 
   // @ts-expect-error window type is not declared, debug only
+  // eslint-disable-next-line react-hooks/immutability
   if (__DEV__ && IS_WEB) window.agent = state.currentAgentState.agent
 
   const agent = state.currentAgentState.agent as BskyAppAgent

--- a/src/state/session/oauth-telemetry.ts
+++ b/src/state/session/oauth-telemetry.ts
@@ -1,0 +1,120 @@
+import {type Metrics} from '#/analytics/metrics'
+
+type OauthTelemetryEvent =
+  | {type: 'oauth:sessionDeleted'; payload: Metrics['oauth:sessionDeleted']}
+  | {type: 'oauth:sessionRefreshed'; payload: Metrics['oauth:sessionRefreshed']}
+  | {type: 'oauth:refreshFailed'; payload: Metrics['oauth:refreshFailed']}
+  | {
+      type: 'oauth:sessionResumeFailed'
+      payload: Metrics['oauth:sessionResumeFailed']
+    }
+
+export type OauthTelemetrySink = (event: OauthTelemetryEvent) => void
+
+let sink: OauthTelemetrySink | null = null
+const pending: OauthTelemetryEvent[] = []
+
+// The browser OAuth client is constructed once at module load, before the
+// React Provider mounts. Until the Provider registers a sink, events are
+// queued in memory so we don't drop early-boot signals (e.g. a failed
+// session restore that happens during initial init()).
+export function setOauthTelemetrySink(next: OauthTelemetrySink | null) {
+  sink = next
+  if (sink && pending.length) {
+    const drained = pending.splice(0, pending.length)
+    for (const event of drained) sink(event)
+  }
+}
+
+export function emitOauthTelemetry(event: OauthTelemetryEvent) {
+  if (sink) {
+    sink(event)
+  } else {
+    pending.push(event)
+    // Bound the queue so a stuck sink can't grow memory unbounded.
+    if (pending.length > 50) pending.shift()
+  }
+}
+
+export function truncateOauthMessage(err: unknown): string | undefined {
+  let str: string
+  if (err instanceof Error) {
+    str = err.message
+  } else if (typeof err === 'string') {
+    str = err
+  } else if (err && typeof err === 'object' && 'message' in err) {
+    str = String((err as {message: unknown}).message)
+  } else {
+    return undefined
+  }
+  return str.slice(0, 200)
+}
+
+export function categorizeOauthError(
+  err: unknown,
+): Metrics['oauth:sessionResumeFailed']['errorCategory'] {
+  let str: string
+  if (err instanceof Error) {
+    str = err.message
+  } else if (typeof err === 'string') {
+    str = err
+  } else if (err && typeof err === 'object' && 'message' in err) {
+    str = String((err as {message: unknown}).message)
+  } else {
+    str = ''
+  }
+  if (
+    str.includes('session was deleted by another process') ||
+    str.includes('The session was revoked')
+  ) {
+    return 'sessionDeleted'
+  }
+  // PDS oauth-provider returns `invalid_grant: Session expired` when the
+  // session age exceeds the public/confidential client lifetime. The OAuth
+  // client surfaces this as Error('Session expired') and follows up by
+  // deleting the local session.
+  if (
+    str.includes('Session expired') ||
+    (str.includes('invalid_grant') && str.includes('Session expired'))
+  ) {
+    return 'sessionExpired'
+  }
+  if (
+    str.includes('Database closed') ||
+    str.includes('Database has been disposed')
+  ) {
+    return 'databaseClosed'
+  }
+  if (str.includes('invalid_dpop_proof') && str.includes('iat claim')) {
+    return 'dpopSkew'
+  }
+  if (str.includes('invalid_dpop_proof')) {
+    return 'dpopOther'
+  }
+  if (str.includes('No refresh token available')) {
+    return 'refreshExhausted'
+  }
+  if (
+    str.includes('Token set sub mismatch') ||
+    str.includes('Stored session sub mismatch')
+  ) {
+    return 'subMismatch'
+  }
+  if (str.includes('timed out') || str.includes('Session resume timed out')) {
+    return 'timeout'
+  }
+  if (
+    str.includes('Failed to fetch') ||
+    str.includes('Network request failed') ||
+    str.includes('Load failed') ||
+    // Firefox raw fetch failure when network is offline / URL is blocked
+    str.includes('NetworkError when attempting to fetch')
+  ) {
+    return 'network'
+  }
+  // Generic invalid_grant catch-all that isn't a known sub-case above.
+  if (str.includes('invalid_grant')) {
+    return 'invalidGrant'
+  }
+  return 'unknown'
+}

--- a/src/state/session/oauth-web-client.ts
+++ b/src/state/session/oauth-web-client.ts
@@ -1,5 +1,13 @@
 import {BrowserOAuthClient} from '@atproto/oauth-client-browser'
 
+import {logger} from '#/logger'
+import {
+  categorizeOauthError,
+  emitOauthTelemetry,
+  truncateOauthMessage,
+} from '#/state/session/oauth-telemetry'
+import {type Metrics} from '#/analytics/metrics'
+
 const OAUTH_BASE_URL: string =
   process.env.EXPO_PUBLIC_OAUTH_BASE_URL || 'https://blacksky.community'
 
@@ -20,7 +28,108 @@ function isLoopback() {
   )
 }
 
-const BSKY_OAUTH_CLIENT = createWebOAuthClient()
+// Marker symbol so HMR re-running this module can't attach two copies of
+// the listeners to the same client instance.
+const TELEMETRY_ATTACHED = Symbol.for('blacksky.oauthTelemetryAttached')
+
+function attachOauthTelemetry(client: BrowserOAuthClient) {
+  const tagged = client as unknown as Record<symbol, true>
+  if (tagged[TELEMETRY_ATTACHED]) return
+  tagged[TELEMETRY_ATTACHED] = true
+  client.addEventListener('deleted', event => {
+    const detail = (event as CustomEvent<{sub: string; cause?: unknown}>).detail
+    const cause = categorizeOauthError(detail.cause)
+    const message =
+      detail.cause instanceof Error
+        ? detail.cause.message
+        : typeof detail.cause === 'string'
+          ? detail.cause
+          : undefined
+    logger.warn('oauth: session deleted', {sub: detail.sub, cause, message})
+    emitOauthTelemetry({
+      type: 'oauth:sessionDeleted',
+      payload: {cause, message: message?.slice(0, 200)},
+    })
+  })
+  client.addEventListener('updated', () => {
+    emitOauthTelemetry({type: 'oauth:sessionRefreshed', payload: {}})
+  })
+}
+
+// Lets the debug button mark the next refresh attempt as user-initiated so
+// the fetch wrapper can label its telemetry accordingly. Cleared after the
+// next /oauth/token round-trip completes.
+let pendingRefreshContext: Metrics['oauth:refreshFailed']['triggerContext'] =
+  'background'
+export function markNextRefreshContext(
+  context: Metrics['oauth:refreshFailed']['triggerContext'],
+) {
+  pendingRefreshContext = context
+}
+
+// Wraps the global fetch so we can observe every OAuth-provider round trip
+// without depending on the OAuth client's higher-level `deleted`/`updated`
+// events. Notably this captures network failures and transient 5xx responses
+// that don't cause the client to delete the session — exactly the class of
+// failures the higher-level events miss.
+const oauthInstrumentedFetch: typeof fetch = async (input, init) => {
+  const url =
+    typeof input === 'string'
+      ? input
+      : input instanceof URL
+        ? input.href
+        : input.url
+  const method =
+    init?.method?.toUpperCase() ??
+    (input instanceof Request ? input.method.toUpperCase() : undefined)
+  const isTokenEndpoint = method === 'POST' && url.includes('/oauth/token')
+  if (!isTokenEndpoint) {
+    return fetch(input, init)
+  }
+  const triggerContext = pendingRefreshContext
+  pendingRefreshContext = 'background'
+  try {
+    const res = await fetch(input, init)
+    if (!res.ok) {
+      // Try to parse the OAuth error response body for categorization.
+      // Clone so we don't consume the body the OAuth client will read next.
+      let errorBody: string | undefined
+      try {
+        errorBody = await res.clone().text()
+      } catch {}
+      // `use_dpop_nonce` is the server's standard request to retry the call
+      // with a freshly-issued DPoP nonce — it's expected control flow at the
+      // start of every refresh, not a failure. Skip it.
+      if (errorBody?.includes('use_dpop_nonce')) {
+        return res
+      }
+      const errorCategory: Metrics['oauth:refreshFailed']['errorCategory'] =
+        res.status >= 500
+          ? 'serverError'
+          : categorizeOauthError(errorBody ?? `HTTP ${res.status}`)
+      emitOauthTelemetry({
+        type: 'oauth:refreshFailed',
+        payload: {
+          triggerContext,
+          errorCategory,
+          httpStatus: res.status,
+          message: errorBody?.slice(0, 200),
+        },
+      })
+    }
+    return res
+  } catch (err) {
+    emitOauthTelemetry({
+      type: 'oauth:refreshFailed',
+      payload: {
+        triggerContext,
+        errorCategory: categorizeOauthError(err),
+        message: truncateOauthMessage(err),
+      },
+    })
+    throw err
+  }
+}
 
 function createWebOAuthClient() {
   if (isLoopback()) {
@@ -47,6 +156,7 @@ function createWebOAuthClient() {
         dpop_bound_access_tokens: true,
       },
       handleResolver: 'https://blacksky.app',
+      fetch: oauthInstrumentedFetch,
     })
   }
 
@@ -64,8 +174,12 @@ function createWebOAuthClient() {
       dpop_bound_access_tokens: true,
     },
     handleResolver: 'https://blacksky.app',
+    fetch: oauthInstrumentedFetch,
   })
 }
+
+const BSKY_OAUTH_CLIENT = createWebOAuthClient()
+attachOauthTelemetry(BSKY_OAUTH_CLIENT)
 
 export function getWebOAuthClient() {
   return BSKY_OAUTH_CLIENT


### PR DESCRIPTION
## Summary
- Map OAuth-specific failure strings to readable user messages in `cleanError`
- Emit `oauth:sessionRefreshed` / `oauth:refreshFailed` / `oauth:sessionDeleted` / `oauth:sessionResumeFailed` to growthbook for silent-logout diagnosis
- Dev-only "Force OAuth token refresh" button under Settings → DevOptions

## Test plan
- [ ] Sign in via OAuth → confirm `oauth:sessionRefreshed` row appears in `growthbook.events`
- [ ] DevTools block `https://blacksky.app/oauth/token` → tap debug button → confirm `oauth:refreshFailed` row with `errorCategory: "network"`
- [ ] Trigger a known DPoP iat skew → confirm friendly error message replaces raw oauth-client string in the UI