### PR TITLE
ci: mirror to forge.blacksky.community

### DIFF
--- a/.github/workflows/tangle.yml
+++ b/.github/workflows/tangle.yml
@@ -37,6 +37,10 @@ jobs:
           # the destination instead of as proper branches. Materialize them
           # under refs/heads/* first so the mirror push lands them as real
           # branches that forge can render.
+          #
+          # Detach HEAD before fetching so the fetch can overwrite
+          # refs/heads/<currently-checked-out-branch> without git refusing.
+          git -c advice.detachedHead=false checkout --detach
           git fetch origin '+refs/heads/*:refs/heads/*' '+refs/tags/*:refs/tags/*'
           git remote add tangled git@knot.blacksky.community:blackskyweb.xyz/blacksky.community
           git push --mirror tangled

--- a/.github/workflows/tangle.yml
+++ b/.github/workflows/tangle.yml
@@ -1,0 +1,19 @@
+name: Mirror to forge.blacksky.community
+
+on:
+  push: {}
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  tangle:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: gwennlbh/to-tangled@6867d16fd934f3fe27df0a540dbd6375ea88b31c # v0.5
+        with:
+          repo: blackskyweb.xyz/blacksky.community
+          knot: knot.blacksky.community
+          ssh-key: ${{ secrets.TANGLED_KEY }}

--- a/.github/workflows/tangle.yml
+++ b/.github/workflows/tangle.yml
@@ -6,14 +6,31 @@ on:
 
 permissions:
   contents: read
-  pull-requests: read
 
 jobs:
   tangle:
     runs-on: ubuntu-latest
     steps:
-      - uses: gwennlbh/to-tangled@6867d16fd934f3fe27df0a540dbd6375ea88b31c # v0.5
+      - uses: actions/checkout@v4
         with:
-          repo: blackskyweb.xyz/blacksky.community
-          knot: knot.blacksky.community
-          ssh-key: ${{ secrets.TANGLED_KEY }}
+          fetch-depth: 0
+      - name: push to forge knot
+        env:
+          TANGLED_KEY: ${{ secrets.TANGLED_KEY }}
+        run: |
+          set -euo pipefail
+          mkdir -p ~/.ssh
+          chmod 700 ~/.ssh
+          printf '%s\n' "$TANGLED_KEY" > ~/.ssh/tangled_key
+          chmod 600 ~/.ssh/tangled_key
+          cat > ~/.ssh/config <<'EOF'
+          Host knot.blacksky.community
+            StrictHostKeyChecking no
+            UserKnownHostsFile=/dev/null
+            IdentityFile ~/.ssh/tangled_key
+            IdentitiesOnly yes
+          EOF
+          chmod 600 ~/.ssh/config
+          git fetch --tags origin
+          git remote add tangled git@knot.blacksky.community:blackskyweb.xyz/blacksky.community
+          git push --mirror tangled

--- a/.github/workflows/tangle.yml
+++ b/.github/workflows/tangle.yml
@@ -31,6 +31,12 @@ jobs:
             IdentitiesOnly yes
           EOF
           chmod 600 ~/.ssh/config
-          git fetch --tags origin
+
+          # actions/checkout leaves origin branches under refs/remotes/origin/*
+          # — git push --mirror would copy those as remote-tracking refs on
+          # the destination instead of as proper branches. Materialize them
+          # under refs/heads/* first so the mirror push lands them as real
+          # branches that forge can render.
+          git fetch origin '+refs/heads/*:refs/heads/*' '+refs/tags/*:refs/tags/*'
           git remote add tangled git@knot.blacksky.community:blackskyweb.xyz/blacksky.community
           git push --mirror tangled


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/tangle.yml` that runs on every push and force-pushes all branches + tags to `forge.blacksky.community/blackskyweb.xyz/blacksky.community` via a small inline `git push --mirror` step.
- Uses repo secret `TANGLED_KEY` (already set).

## Notes
- One-way mirror. GitHub stays the source of truth.
- ~159MB on first sync; subsequent runs are incremental.
- The `ci/forge-mirror` branch will be pruned from forge automatically when this PR merges + the branch is deleted.

## Test plan
- [ ] After merge, visit https://forge.blacksky.community/blackskyweb.xyz/blacksky.community — `main` should be the default branch.
- [ ] Push a trivial change (or `workflow_dispatch`) and confirm forge updates.
