### PR TITLE
feat(gifs): add klipy as a renderable option

### DIFF
--- a/src/components/MediaPreview.tsx
+++ b/src/components/MediaPreview.tsx
@@ -3,7 +3,7 @@ import {Image} from 'expo-image'
 import {type AppBskyFeedDefs} from '@atproto/api'
 import {Trans} from '@lingui/macro'
 
-import {isTenorGifUri} from '#/lib/strings/embed-player'
+import {isGifEmbed} from '#/lib/strings/embed-player'
 import {atoms as a, useTheme} from '#/alf'
 import {MediaInsetBorder} from '#/components/MediaInsetBorder'
 import {Text} from '#/components/Typography'
@@ -38,7 +38,7 @@ export function Embed({
     )
   } else if (e.type === 'link') {
     if (!e.view.external.thumb) return null
-    if (!isTenorGifUri(e.view.external.uri)) return null
+    if (!isGifEmbed(e.view.external.uri)) return null
     return (
       <Outer style={style}>
         <GifItem

--- a/src/components/Post/Embed/ExternalEmbed/index.tsx
+++ b/src/components/Post/Embed/ExternalEmbed/index.tsx
@@ -68,7 +68,7 @@ export const ExternalEmbed = ({
     )
   }
 
-  if (embedPlayerParams?.source === 'tenor') {
+  if (embedPlayerParams?.source === 'tenor' || embedPlayerParams?.source === 'klipy') {
     const parsedAlt = parseAltFromGIFDescription(link.description)
     return (
       <View style={style}>

--- a/src/lib/strings/embed-player.ts
+++ b/src/lib/strings/embed-player.ts
@@ -23,6 +23,7 @@ export const embedPlayerSources = [
   'vimeo',
   'giphy',
   'tenor',
+  'klipy',
   'flickr',
   'assembly',
 ] as const
@@ -44,6 +45,7 @@ export type EmbedPlayerType =
   | 'vimeo_video'
   | 'giphy_gif'
   | 'tenor_gif'
+  | 'klipy_gif'
   | 'flickr_album'
   | 'assembly_conversation'
 
@@ -54,6 +56,7 @@ export const externalEmbedLabels: Record<EmbedPlayerSource, string> = {
   twitch: 'Twitch',
   giphy: 'GIPHY',
   tenor: 'Tenor',
+  klipy: 'Klipy',
   spotify: 'Spotify',
   appleMusic: 'Apple Music',
   soundcloud: 'SoundCloud',
@@ -376,6 +379,19 @@ export function parseEmbedPlayerFromUrl(
     }
   }
 
+  const klipyGif = parseKlipyGif(urlp)
+  if (klipyGif.success) {
+    const {playerUri, dimensions} = klipyGif
+    return {
+      type: 'klipy_gif',
+      source: 'klipy',
+      isGif: true,
+      hideDetails: true,
+      playerUri,
+      dimensions,
+    }
+  }
+
   const tenorGif = parseTenorGif(urlp)
   if (tenorGif.success) {
     const {playerUri, dimensions} = tenorGif
@@ -609,7 +625,83 @@ export function isTenorGifUri(url: URL | string) {
   try {
     return parseTenorGif(typeof url === 'string' ? new URL(url) : url).success
   } catch {
-    // Invalid URL
     return false
   }
+}
+
+export function parseKlipyGif(urlp: URL):
+  | {success: false}
+  | {
+      success: true
+      playerUri: string
+      dimensions: {height: number; width: number}
+    } {
+  if (urlp.hostname !== 'static.klipy.com') {
+    return {success: false}
+  }
+
+  if (!urlp.pathname.startsWith('/ii/')) {
+    return {success: false}
+  }
+
+  const h = urlp.searchParams.get('hh')
+  const w = urlp.searchParams.get('ww')
+
+  if (!h || !w) {
+    return {success: false}
+  }
+
+  const dimensions = {
+    height: Number(h),
+    width: Number(w),
+  }
+
+  if (
+    isNaN(dimensions.height) ||
+    isNaN(dimensions.width) ||
+    dimensions.height <= 0 ||
+    dimensions.width <= 0
+  ) {
+    return {success: false}
+  }
+
+  const playerUrl = new URL(urlp.href)
+  playerUrl.hostname = 'k.gifs.bsky.app'
+
+  if (IS_WEB) {
+    const mp4Slug = playerUrl.searchParams.get('mp4')
+    const webmSlug = playerUrl.searchParams.get('webm')
+    if (IS_WEB_SAFARI) {
+      if (mp4Slug) {
+        playerUrl.pathname = playerUrl.pathname.replace(/\.[^.]+$/, '.mp4')
+      }
+    } else {
+      if (webmSlug) {
+        playerUrl.pathname = playerUrl.pathname.replace(/\.[^.]+$/, '.webm')
+      }
+    }
+  }
+
+  playerUrl.searchParams.delete('hh')
+  playerUrl.searchParams.delete('ww')
+  playerUrl.searchParams.delete('mp4')
+  playerUrl.searchParams.delete('webm')
+
+  return {
+    success: true,
+    playerUri: playerUrl.toString(),
+    dimensions,
+  }
+}
+
+export function isKlipyGifUri(url: URL | string) {
+  try {
+    return parseKlipyGif(typeof url === 'string' ? new URL(url) : url).success
+  } catch {
+    return false
+  }
+}
+
+export function isGifEmbed(url: URL | string) {
+  return isTenorGifUri(url) || isKlipyGifUri(url)
 }

--- a/src/lib/strings/embed-player.ts
+++ b/src/lib/strings/embed-player.ts
@@ -669,17 +669,18 @@ export function parseKlipyGif(urlp: URL):
   playerUrl.hostname = 'k.gifs.bsky.app'
 
   if (IS_WEB) {
-    const mp4Slug = playerUrl.searchParams.get('mp4')
     const webmSlug = playerUrl.searchParams.get('webm')
-    if (IS_WEB_SAFARI) {
-      if (mp4Slug) {
-        playerUrl.pathname = playerUrl.pathname.replace(/\.[^.]+$/, '.mp4')
-      }
-    } else {
-      if (webmSlug) {
-        playerUrl.pathname = playerUrl.pathname.replace(/\.[^.]+$/, '.webm')
-      }
+    const mp4Slug = playerUrl.searchParams.get('mp4')
+    const slug = IS_WEB_SAFARI ? mp4Slug : webmSlug
+    const ext = IS_WEB_SAFARI ? 'mp4' : 'webm'
+
+    if (!slug) {
+      return {success: false}
     }
+
+    const parts = playerUrl.pathname.split('/')
+    parts[parts.length - 1] = `${slug}.${ext}`
+    playerUrl.pathname = parts.join('/')
   }
 
   playerUrl.searchParams.delete('hh')

--- a/src/state/persisted/schema.ts
+++ b/src/state/persisted/schema.ts
@@ -99,6 +99,7 @@ const schema = z.object({
     .object({
       giphy: z.enum(externalEmbedOptions).optional(),
       tenor: z.enum(externalEmbedOptions).optional(),
+      klipy: z.enum(externalEmbedOptions).optional(),
       youtube: z.enum(externalEmbedOptions).optional(),
       youtubeShorts: z.enum(externalEmbedOptions).optional(),
       twitch: z.enum(externalEmbedOptions).optional(),


### PR DESCRIPTION
As demonstrated [in this video](https://blacksky.community/profile/did:plc:e2ctbutx6kya6si4if5ngjmm/post/3ml7ka4td2s2y), this serves as a patch to changes made in https://github.com/bluesky-social/social-app/pull/10261/changes to allow GIFs served from Bluesky's new provider of GIFs to show up as native GIF-ified videos.

I should note that this is a temporary fix. I think it'd make sense to cherry-pick the refactor that they made upstream around GIF selection (peep the linked PR). I have a pending PR for that that would make this work obsolete.