### PR TITLE
Account deactivation

### DIFF
--- a/eslint-suppressions.json
+++ b/eslint-suppressions.json
@@ -134,17 +134,7 @@
       "count": 1
     }
   },
-  "src/components/dialogs/DeviceLocationRequestDialog.tsx": {
-    "@typescript-eslint/no-explicit-any": {
-      "count": 1
-    }
-  },
   "src/components/dialogs/EmailDialog/components/ResendEmailText.tsx": {
-    "@typescript-eslint/no-explicit-any": {
-      "count": 1
-    }
-  },
-  "src/components/dialogs/GifSelect.tsx": {
     "@typescript-eslint/no-explicit-any": {
       "count": 1
     }
@@ -227,11 +217,6 @@
   "src/features/liveNow/index.tsx": {
     "@typescript-eslint/no-explicit-any": {
       "count": 3
-    }
-  },
-  "src/geolocation/service.ts": {
-    "@typescript-eslint/no-explicit-any": {
-      "count": 2
     }
   },
   "src/lib/ScrollContext.tsx": {
@@ -360,11 +345,6 @@
     }
   },
   "src/screens/Bookmarks/index.tsx": {
-    "@typescript-eslint/no-explicit-any": {
-      "count": 1
-    }
-  },
-  "src/screens/Deactivated.tsx": {
     "@typescript-eslint/no-explicit-any": {
       "count": 1
     }
@@ -587,21 +567,6 @@
   "src/view/com/feeds/ProfileFeedgens.tsx": {
     "@typescript-eslint/no-explicit-any": {
       "count": 3
-    }
-  },
-  "src/view/com/lightbox/ImageViewing/@types/index.ts": {
-    "@typescript-eslint/no-explicit-any": {
-      "count": 1
-    }
-  },
-  "src/view/com/lightbox/ImageViewing/components/ImageItem/ImageItem.android.tsx": {
-    "@typescript-eslint/no-explicit-any": {
-      "count": 1
-    }
-  },
-  "src/view/com/lightbox/ImageViewing/index.tsx": {
-    "@typescript-eslint/no-explicit-any": {
-      "count": 1
     }
   },
   "src/view/com/lists/ListMembers.tsx": {

--- a/src/lib/strings/errors.ts
+++ b/src/lib/strings/errors.ts
@@ -71,7 +71,13 @@ export function cleanError(str: any): string {
     return t`Account has been suspended`
   }
   if (str.includes('Account is deactivated')) {
-    return t`Account is deactivated`
+    return t`Your account is deactivated. If you recently moved to a new hosting provider, reactivate to complete the migration.`
+  }
+  if (str.includes('Account has been taken down')) {
+    return t`Account has been taken down`
+  }
+  if (str.includes('Account has been deleted')) {
+    return t`Account has been deleted`
   }
   if (str.includes('Profile not found')) {
     return t`Profile not found`

--- a/src/locale/locales/en/messages.po
+++ b/src/locale/locales/en/messages.po
@@ -581,6 +581,11 @@ msgstr ""
 msgid "{userName}'s verifications"
 msgstr ""
 
+#. placeholder {0}: currentAccount?.handle
+#: src/screens/Deactivated.tsx:176
+msgid "@{0} is currently deactivated. If you recently moved to a new hosting provider, this is expected — reactivation is the last step to complete the migration."
+msgstr "@{0} is currently deactivated. If you recently moved to a new hosting provider, this is expected — reactivation is the last step to complete the migration."
+
 #. Indicates the number of additional profiles are in the Starter Pack e.g. +12
 #: src/screens/Search/components/StarterPackCard.tsx:250
 msgid "+{computedTotal}"
@@ -755,7 +760,7 @@ msgid "Accessibility Settings"
 msgstr ""
 
 #: src/Navigation.tsx:425
-#: src/screens/Login/LoginForm.tsx:76
+#: src/screens/Login/LoginForm.tsx:86
 #: src/screens/Settings/AccountSettings.tsx:69
 #: src/screens/Settings/Settings.tsx:167
 #: src/screens/Settings/Settings.tsx:170
@@ -770,6 +775,10 @@ msgctxt "toast"
 msgid "Account blocked"
 msgstr ""
 
+#: src/screens/Profile/components/ProfileStatusError.tsx:52
+msgid "Account deactivated"
+msgstr "Account deactivated"
+
 #: src/view/com/modals/DeleteAccount.tsx:71
 msgid "Account deletion is not available when signed in with OAuth. Please manage your account through your hosting provider's website."
 msgstr "Account deletion is not available when signed in with OAuth. Please manage your account through your hosting provider's website."
@@ -779,13 +788,42 @@ msgctxt "toast"
 msgid "Account followed"
 msgstr ""
 
+#: src/lib/strings/errors.ts:80
+msgid "Account has been deleted"
+msgstr "Account has been deleted"
+
 #: src/lib/strings/errors.ts:71
 msgid "Account has been suspended"
 msgstr ""
 
-#: src/lib/strings/errors.ts:74
-msgid "Account is deactivated"
-msgstr ""
+#: src/lib/strings/errors.ts:77
+msgid "Account has been taken down"
+msgstr "Account has been taken down"
+
+#: src/screens/Deactivated.tsx:102
+msgid "Account is missing PDS information. Please sign in again."
+msgstr "Account is missing PDS information. Please sign in again."
+
+#. placeholder {0}: source.handle
+#: src/screens/Profile/components/ProfileStatusError.tsx:76
+msgid "Account is suspended by @{0}."
+msgstr "Account is suspended by @{0}."
+
+#. placeholder {0}: source.handle
+#. placeholder {1}: source.email
+#: src/screens/Profile/components/ProfileStatusError.tsx:117
+msgid "Account is suspended by <0>@{0}</0>, email <1>{1}</1> to appeal."
+msgstr "Account is suspended by <0>@{0}</0>, email <1>{1}</1> to appeal."
+
+#. placeholder {0}: source.handle
+#: src/screens/Profile/components/ProfileStatusError.tsx:96
+msgid "Account is suspended by <0>@{0}</0>. Click <1>here</1> to submit an appeal."
+msgstr "Account is suspended by <0>@{0}</0>. Click <1>here</1> to submit an appeal."
+
+#: src/screens/Profile/components/ProfileStatusError.tsx:67
+#: src/screens/Profile/components/ProfileStatusError.tsx:82
+msgid "Account is suspended."
+msgstr "Account is suspended."
 
 #: src/components/PostControls/PostMenu/PostMenuItems.tsx:454
 #: src/view/com/profile/ProfileMenu.tsx:160
@@ -818,6 +856,10 @@ msgstr ""
 #: src/screens/Settings/Settings.tsx:633
 msgid "Account removed from quick access"
 msgstr ""
+
+#: src/screens/Profile/components/ProfileStatusError.tsx:60
+msgid "Account suspended"
+msgstr "Account suspended"
 
 #: src/screens/Messages/ConversationSettings/MemberMenu.tsx:103
 #: src/screens/Profile/Header/ProfileHeaderStandard.tsx:88
@@ -885,7 +927,7 @@ msgid "Add a user to this list"
 msgstr ""
 
 #: src/components/dialogs/SwitchAccount.tsx:56
-#: src/screens/Deactivated.tsx:184
+#: src/screens/Deactivated.tsx:262
 msgid "Add account"
 msgstr ""
 
@@ -1638,8 +1680,8 @@ msgstr ""
 #: src/screens/Login/ChooseAccountForm.tsx:113
 #: src/screens/Login/ForgotPasswordForm.tsx:124
 #: src/screens/Login/ForgotPasswordForm.tsx:130
-#: src/screens/Login/LoginForm.tsx:106
-#: src/screens/Login/LoginForm.tsx:112
+#: src/screens/Login/LoginForm.tsx:116
+#: src/screens/Login/LoginForm.tsx:122
 #: src/screens/Login/SetNewPasswordForm.tsx:170
 #: src/screens/Login/SetNewPasswordForm.tsx:176
 #: src/screens/Messages/components/ChatDisabled.tsx:148
@@ -1683,7 +1725,7 @@ msgstr ""
 #: src/components/dialogs/StarterPackDialog.tsx:72
 #: src/components/StarterPack/ProfileStarterPacks.tsx:264
 #: src/components/StarterPack/ProfileStarterPacks.tsx:274
-#: src/view/screens/Profile.tsx:349
+#: src/view/screens/Profile.tsx:374
 msgid "Before creating a starter pack, you must first verify your email."
 msgstr ""
 
@@ -2012,7 +2054,7 @@ msgstr ""
 #: src/features/liveNow/components/GoLiveDialog.tsx:248
 #: src/features/liveNow/components/GoLiveDialog.tsx:254
 #: src/lib/media/picker.tsx:38
-#: src/screens/Deactivated.tsx:150
+#: src/screens/Deactivated.tsx:228
 #: src/screens/Messages/ConversationSettings/prompts.tsx:68
 #: src/screens/Messages/ConversationSettings/prompts.tsx:92
 #: src/screens/Profile/Header/EditProfileDialog.tsx:229
@@ -2052,7 +2094,7 @@ msgstr "Cancel account deletion"
 msgid "Cancel quote post"
 msgstr ""
 
-#: src/screens/Deactivated.tsx:144
+#: src/screens/Deactivated.tsx:222
 msgid "Cancel reactivation and sign out"
 msgstr ""
 
@@ -2559,6 +2601,10 @@ msgstr ""
 msgid "Confirm delete account"
 msgstr "Confirm delete account"
 
+#: src/screens/Deactivated.tsx:192
+msgid "Confirm with your account password"
+msgstr "Confirm with your account password"
+
 #: src/components/dialogs/EmailDialog/components/TokenField.tsx:38
 #: src/screens/Settings/components/ChangePasswordDialog.tsx:187
 #: src/screens/Settings/components/ChangePasswordDialog.tsx:191
@@ -2870,6 +2916,10 @@ msgstr ""
 msgid "Couldn’t load GIFs"
 msgstr "Couldn’t load GIFs"
 
+#: src/screens/Deactivated.tsx:143
+msgid "Couldn't reactivate the account. Please try again."
+msgstr "Couldn't reactivate the account. Please try again."
+
 #: src/components/InternationalPhoneCodeSelect.tsx:77
 msgid "Country code"
 msgstr ""
@@ -2902,8 +2952,8 @@ msgstr ""
 msgid "Create a starter pack"
 msgstr ""
 
-#: src/view/screens/Profile.tsx:561
-#: src/view/screens/Profile.tsx:562
+#: src/view/screens/Profile.tsx:586
+#: src/view/screens/Profile.tsx:587
 msgid "Create a Starter Pack"
 msgstr ""
 
@@ -3887,7 +3937,7 @@ msgstr ""
 msgid "Enter your email address"
 msgstr ""
 
-#: src/screens/Login/LoginForm.tsx:97
+#: src/screens/Login/LoginForm.tsx:107
 msgid "Enter your handle (e.g. alice.bsky.social)"
 msgstr "Enter your handle (e.g. alice.bsky.social)"
 
@@ -4419,7 +4469,7 @@ msgstr ""
 #: src/screens/Search/SearchResults.tsx:81
 #: src/screens/StarterPack/StarterPackScreen.tsx:196
 #: src/view/screens/Feeds.tsx:503
-#: src/view/screens/Profile.tsx:238
+#: src/view/screens/Profile.tsx:263
 #: src/view/shell/desktop/LeftNav.tsx:733
 #: src/view/shell/Drawer.tsx:525
 msgid "Feeds"
@@ -5546,6 +5596,10 @@ msgstr ""
 msgid "Inbox zero!"
 msgstr ""
 
+#: src/screens/Deactivated.tsx:137
+msgid "Incorrect password. Please try again."
+msgstr "Incorrect password. Please try again."
+
 #: src/screens/Settings/AIPreferencesSettings.tsx:222
 msgid "Inference"
 msgstr "Inference"
@@ -5733,7 +5787,7 @@ msgid "Labeled by the author."
 msgstr ""
 
 #: src/view/com/composer/labels/LabelsBtn.tsx:70
-#: src/view/screens/Profile.tsx:231
+#: src/view/screens/Profile.tsx:256
 msgid "Labels"
 msgstr ""
 
@@ -5956,7 +6010,7 @@ msgstr ""
 #: src/lib/hooks/useNotificationHandler.ts:136
 #: src/screens/Settings/NotificationSettings/index.tsx:127
 #: src/screens/Settings/NotificationSettings/LikeNotificationSettings.tsx:41
-#: src/view/screens/Profile.tsx:237
+#: src/view/screens/Profile.tsx:262
 msgid "Likes"
 msgstr ""
 
@@ -6071,8 +6125,8 @@ msgstr ""
 
 #: src/Navigation.tsx:185
 #: src/view/screens/Lists.tsx:60
-#: src/view/screens/Profile.tsx:232
-#: src/view/screens/Profile.tsx:240
+#: src/view/screens/Profile.tsx:257
+#: src/view/screens/Profile.tsx:265
 #: src/view/shell/desktop/LeftNav.tsx:751
 #: src/view/shell/Drawer.tsx:540
 msgid "Lists"
@@ -6187,8 +6241,8 @@ msgstr ""
 msgid "Logged-out visibility"
 msgstr ""
 
-#: src/screens/Login/LoginForm.tsx:118
-#: src/screens/Login/LoginForm.tsx:125
+#: src/screens/Login/LoginForm.tsx:128
+#: src/screens/Login/LoginForm.tsx:135
 msgid "Login"
 msgstr "Login"
 
@@ -6281,7 +6335,7 @@ msgstr "Maximum support amount is $1,000"
 msgid "Maybe later"
 msgstr ""
 
-#: src/view/screens/Profile.tsx:235
+#: src/view/screens/Profile.tsx:260
 msgid "Media"
 msgstr ""
 
@@ -6784,7 +6838,7 @@ msgstr ""
 #: src/screens/ProfileList/index.tsx:292
 #: src/view/screens/Feeds.tsx:544
 #: src/view/screens/Notifications.tsx:166
-#: src/view/screens/Profile.tsx:592
+#: src/view/screens/Profile.tsx:617
 msgid "New post"
 msgstr ""
 
@@ -6903,7 +6957,7 @@ msgstr ""
 
 #: src/components/LikedByList.tsx:84
 #: src/view/com/post-thread/PostLikedBy.tsx:84
-#: src/view/screens/Profile.tsx:524
+#: src/view/screens/Profile.tsx:549
 msgid "No likes yet"
 msgstr ""
 
@@ -6920,7 +6974,7 @@ msgstr ""
 msgid "No longer following {0}"
 msgstr ""
 
-#: src/view/screens/Profile.tsx:470
+#: src/view/screens/Profile.tsx:495
 msgid "No media yet"
 msgstr ""
 
@@ -6966,7 +7020,7 @@ msgid "No posts here"
 msgstr ""
 
 #: src/screens/Profile/Sections/Feed.tsx:81
-#: src/view/screens/Profile.tsx:429
+#: src/view/screens/Profile.tsx:454
 msgid "No posts yet"
 msgstr ""
 
@@ -6983,7 +7037,7 @@ msgstr ""
 msgid "No recent GIFs yet. Pick one to see it here."
 msgstr "No recent GIFs yet. Pick one to see it here."
 
-#: src/view/screens/Profile.tsx:455
+#: src/view/screens/Profile.tsx:480
 msgid "No replies yet"
 msgstr ""
 
@@ -7016,7 +7070,7 @@ msgstr ""
 msgid "No results found for “<0>{query}</0>”."
 msgstr "No results found for “<0>{query}</0>”."
 
-#: src/view/screens/Profile.tsx:556
+#: src/view/screens/Profile.tsx:581
 msgid "No Starter Packs yet"
 msgstr ""
 
@@ -7029,7 +7083,7 @@ msgstr ""
 msgid "No translation received from your device."
 msgstr "No translation received from your device."
 
-#: src/view/screens/Profile.tsx:497
+#: src/view/screens/Profile.tsx:522
 msgid "No video posts yet"
 msgstr ""
 
@@ -7075,8 +7129,12 @@ msgstr ""
 msgid "Not followed by anyone you're following"
 msgstr ""
 
+#: src/screens/Profile/components/ProfileStatusError.tsx:44
+msgid "Not found"
+msgstr "Not found"
+
 #: src/Navigation.tsx:180
-#: src/view/screens/Profile.tsx:132
+#: src/view/screens/Profile.tsx:146
 msgid "Not Found"
 msgstr ""
 
@@ -7260,7 +7318,7 @@ msgstr ""
 #: src/components/StarterPack/ProfileStarterPacks.tsx:372
 #: src/screens/Settings/AppPasswords.tsx:149
 #: src/screens/Settings/components/ChangeHandleDialog.tsx:109
-#: src/view/screens/Profile.tsx:132
+#: src/view/screens/Profile.tsx:146
 msgid "Oops!"
 msgstr ""
 
@@ -7498,11 +7556,11 @@ msgstr "Opens your hosting provider's account management page"
 msgid "Options:"
 msgstr ""
 
-#: src/screens/Deactivated.tsx:192
+#: src/screens/Deactivated.tsx:270
 msgid "Or, continue with another account."
 msgstr ""
 
-#: src/screens/Deactivated.tsx:179
+#: src/screens/Deactivated.tsx:257
 msgid "Or, sign in to one of your other accounts."
 msgstr ""
 
@@ -7584,6 +7642,7 @@ msgstr ""
 msgid "Party GIFs"
 msgstr "Party GIFs"
 
+#: src/screens/Deactivated.tsx:197
 #: src/screens/Settings/AccountSettings.tsx:141
 #: src/screens/Settings/AccountSettings.tsx:145
 #: src/screens/Settings/AppPasswords.tsx:104
@@ -7891,7 +7950,7 @@ msgstr "Please enter your password:"
 msgid "Please enter your password."
 msgstr "Please enter your password."
 
-#: src/screens/Login/LoginForm.tsx:42
+#: src/screens/Login/LoginForm.tsx:46
 msgid "Please enter your username or handle"
 msgstr "Please enter your username or handle"
 
@@ -7962,13 +8021,13 @@ msgctxt "description"
 msgid "Post"
 msgstr ""
 
-#: src/view/screens/Profile.tsx:474
-#: src/view/screens/Profile.tsx:475
+#: src/view/screens/Profile.tsx:499
+#: src/view/screens/Profile.tsx:500
 msgid "Post a photo"
 msgstr ""
 
-#: src/view/screens/Profile.tsx:501
-#: src/view/screens/Profile.tsx:502
+#: src/view/screens/Profile.tsx:526
+#: src/view/screens/Profile.tsx:527
 msgid "Post a video"
 msgstr ""
 
@@ -8066,7 +8125,7 @@ msgstr ""
 #: src/screens/ProfileList/index.tsx:167
 #: src/screens/Settings/NotificationSettings/ActivityNotificationSettings.tsx:219
 #: src/screens/StarterPack/StarterPackScreen.tsx:197
-#: src/view/screens/Profile.tsx:233
+#: src/view/screens/Profile.tsx:258
 msgid "Posts"
 msgstr ""
 
@@ -8176,6 +8235,7 @@ msgstr ""
 msgid "profile"
 msgstr ""
 
+#: src/screens/Profile/components/ProfileStatusError.tsx:149
 #: src/view/shell/bottom-bar/BottomBar.tsx:294
 #: src/view/shell/desktop/LeftNav.tsx:792
 #: src/view/shell/Drawer.tsx:79
@@ -8187,7 +8247,7 @@ msgstr ""
 msgid "Profile banner placeholder"
 msgstr "Profile banner placeholder"
 
-#: src/lib/strings/errors.ts:77
+#: src/lib/strings/errors.ts:83
 msgid "Profile not found"
 msgstr ""
 
@@ -8329,9 +8389,17 @@ msgstr ""
 msgid "Reactions"
 msgstr "Reactions"
 
-#: src/screens/Deactivated.tsx:133
+#: src/screens/Deactivated.tsx:217
+msgid "Reactivate my account"
+msgstr "Reactivate my account"
+
+#: src/screens/Deactivated.tsx:210
 msgid "Reactivate your account"
 msgstr ""
+
+#: src/screens/Deactivated.tsx:183
+msgid "Reactivating will restore visibility of your profile and posts to other users."
+msgstr "Reactivating will restore visibility of your profile and posts to other users."
 
 #. placeholder {0}: item.moreReplies
 #: src/screens/PostThread/components/ThreadItemReadMore.tsx:93
@@ -8657,7 +8725,7 @@ msgstr ""
 #: src/screens/Settings/NotificationSettings/ActivityNotificationSettings.tsx:221
 #: src/screens/Settings/NotificationSettings/index.tsx:149
 #: src/screens/Settings/NotificationSettings/ReplyNotificationSettings.tsx:41
-#: src/view/screens/Profile.tsx:234
+#: src/view/screens/Profile.tsx:259
 msgid "Replies"
 msgstr ""
 
@@ -9857,7 +9925,7 @@ msgstr ""
 #: src/screens/Hashtag.tsx:228
 #: src/screens/Login/index.tsx:119
 #: src/screens/Login/index.tsx:133
-#: src/screens/Login/LoginForm.tsx:73
+#: src/screens/Login/LoginForm.tsx:83
 #: src/screens/Search/SearchResults.tsx:317
 #: src/view/com/auth/SplashScreen.tsx:118
 #: src/view/com/auth/SplashScreen.tsx:124
@@ -9889,8 +9957,8 @@ msgstr "Sign in failed. Please try again."
 msgid "Sign in is taking too long. Please try again."
 msgstr "Sign in is taking too long. Please try again."
 
-#: src/screens/Deactivated.tsx:195
-#: src/screens/Deactivated.tsx:201
+#: src/screens/Deactivated.tsx:273
+#: src/screens/Deactivated.tsx:279
 msgid "Sign in or create an account"
 msgstr ""
 
@@ -10054,7 +10122,6 @@ msgid "Something went wrong"
 msgstr ""
 
 #: src/components/moderation/ReportDialog/index.tsx:291
-#: src/screens/Deactivated.tsx:86
 #: src/screens/Settings/components/DeactivateAccountDialog.tsx:85
 #: src/view/screens/Storybook/Admonitions.tsx:56
 msgid "Something went wrong, please try again"
@@ -10173,7 +10240,7 @@ msgstr ""
 msgid "Starter pack is invalid"
 msgstr ""
 
-#: src/view/screens/Profile.tsx:239
+#: src/view/screens/Profile.tsx:264
 msgid "Starter Packs"
 msgstr ""
 
@@ -10185,11 +10252,11 @@ msgstr ""
 msgid "Starter packs let you share your favorite feeds and people with your friends."
 msgstr ""
 
-#: src/view/screens/Profile.tsx:554
+#: src/view/screens/Profile.tsx:579
 msgid "Starter Packs let you share your favorite feeds and people with your friends."
 msgstr ""
 
-#: src/screens/Login/LoginForm.tsx:119
+#: src/screens/Login/LoginForm.tsx:129
 msgid "Starts the sign-in process"
 msgstr "Starts the sign-in process"
 
@@ -10758,6 +10825,10 @@ msgstr ""
 msgid "This account has a checkmark because it's been verified by trusted sources."
 msgstr ""
 
+#: src/screens/Profile/components/ProfileStatusError.tsx:55
+msgid "This account has been deactivated by its owner."
+msgstr "This account has been deactivated by its owner."
+
 #: src/components/BotAccountAlert.tsx:27
 msgid "This account has been marked as automated by its owner."
 msgstr "This account has been marked as automated by its owner."
@@ -11133,6 +11204,7 @@ msgid "Toggles the sound"
 msgstr ""
 
 #: src/components/contacts/screens/VerifyNumber.tsx:123
+#: src/screens/Deactivated.tsx:140
 msgid "Too many attempts. Please wait a few minutes and try again."
 msgstr ""
 
@@ -11241,6 +11313,10 @@ msgstr ""
 msgid "Two-factor authentication (2FA)"
 msgstr ""
 
+#: src/screens/Deactivated.tsx:130
+msgid "Two-factor authentication is required to reactivate. Please disable 2FA temporarily, or contact support."
+msgstr "Two-factor authentication is required to reactivate. Please disable 2FA temporarily, or contact support."
+
 #: src/screens/Messages/components/MessageInput.tsx:174
 msgid "Type your message here"
 msgstr ""
@@ -11259,9 +11335,10 @@ msgstr ""
 msgid "Unable to contact your service. Please check your internet connection and try again."
 msgstr ""
 
+#: src/screens/Deactivated.tsx:121
 #: src/screens/Login/ForgotPasswordForm.tsx:69
 #: src/screens/Login/index.tsx:92
-#: src/screens/Login/LoginForm.tsx:62
+#: src/screens/Login/LoginForm.tsx:72
 #: src/screens/Login/SetNewPasswordForm.tsx:83
 #: src/screens/Signup/index.tsx:89
 msgid "Unable to contact your service. Please check your Internet connection."
@@ -11271,7 +11348,7 @@ msgstr ""
 msgid "Unable to delete"
 msgstr ""
 
-#: src/lib/strings/errors.ts:80
+#: src/lib/strings/errors.ts:86
 msgid "Unable to resolve handle"
 msgstr ""
 
@@ -11656,7 +11733,7 @@ msgstr "Use your data in AI search and recommendation systems. This is how AI fi
 msgid "Use your data to build or train new AI models. Once your work is in a model, it stays there, even if you delete your account later."
 msgstr "Use your data to build or train new AI models. Once your work is in a model, it stays there, even if you delete your account later."
 
-#: src/view/screens/Profile.tsx:382
+#: src/view/screens/Profile.tsx:407
 msgid "user"
 msgstr "user"
 
@@ -11731,7 +11808,7 @@ msgstr "Username must be at least 3 characters"
 msgid "Username must only contain letters (a-z), numbers, and hyphens"
 msgstr ""
 
-#: src/screens/Login/LoginForm.tsx:83
+#: src/screens/Login/LoginForm.tsx:93
 msgid "Username or handle"
 msgstr "Username or handle"
 
@@ -11887,7 +11964,7 @@ msgstr ""
 msgid "Video: {0}"
 msgstr ""
 
-#: src/view/screens/Profile.tsx:236
+#: src/view/screens/Profile.tsx:261
 msgid "Videos"
 msgstr ""
 
@@ -12090,6 +12167,10 @@ msgstr "We could not connect to the service that provides this custom feed. It m
 msgid "We could not find this list. It was probably deleted."
 msgstr ""
 
+#: src/screens/Profile/components/ProfileStatusError.tsx:47
+msgid "We couldn't find an account at {didOrHandle}."
+msgstr "We couldn't find an account at {didOrHandle}."
+
 #: src/screens/Hashtag.tsx:259
 msgid "We couldn't find any results for that tag."
 msgstr ""
@@ -12214,7 +12295,7 @@ msgstr ""
 msgid "We're sorry! You can only subscribe to twenty labelers, and you've reached your limit of twenty."
 msgstr ""
 
-#: src/screens/Deactivated.tsx:117
+#: src/screens/Deactivated.tsx:173
 msgid "Welcome back!"
 msgstr ""
 
@@ -12315,8 +12396,8 @@ msgstr ""
 msgid "Would you like to save this as a draft to edit later?"
 msgstr ""
 
-#: src/view/screens/Profile.tsx:433
-#: src/view/screens/Profile.tsx:434
+#: src/view/screens/Profile.tsx:458
+#: src/view/screens/Profile.tsx:459
 msgid "Write a post"
 msgstr ""
 
@@ -12371,10 +12452,6 @@ msgstr ""
 
 #: src/components/PostControls/PostMenu/PostMenuItems.tsx:812
 msgid "Yes, hide"
-msgstr ""
-
-#: src/screens/Deactivated.tsx:139
-msgid "Yes, reactivate my account"
 msgstr ""
 
 #: src/components/dms/DateDivider.tsx:45
@@ -12490,10 +12567,6 @@ msgstr ""
 
 #: src/view/com/composer/SelectMediaButton.tsx:425
 msgid "You can only select one video at a time."
-msgstr ""
-
-#: src/screens/Deactivated.tsx:125
-msgid "You can reactivate your account to continue logging in. Your profile and posts will be visible to other users."
 msgstr ""
 
 #. Error message for maximum number of images that can be selected to add to a post, currently 4 but may change.
@@ -12689,11 +12762,6 @@ msgstr ""
 msgid "You need to verify your email address before you can enable email 2FA."
 msgstr ""
 
-#. placeholder {0}: currentAccount?.handle
-#: src/screens/Deactivated.tsx:120
-msgid "You previously deactivated @{0}."
-msgstr ""
-
 #: src/screens/Settings/Settings.tsx:410
 msgid "You probably want to restart the app now."
 msgstr ""
@@ -12773,7 +12841,6 @@ msgstr ""
 msgid "You're in line"
 msgstr ""
 
-#: src/screens/Deactivated.tsx:81
 #: src/screens/Settings/components/DeactivateAccountDialog.tsx:77
 msgid "You're signed in with an App Password. Please sign in with your main password to continue deactivating your account."
 msgstr ""
@@ -12842,6 +12909,10 @@ msgstr ""
 #: src/screens/Takendown.tsx:142
 msgid "Your account has been suspended"
 msgstr ""
+
+#: src/lib/strings/errors.ts:74
+msgid "Your account is deactivated. If you recently moved to a new hosting provider, reactivate to complete the migration."
+msgstr "Your account is deactivated. If you recently moved to a new hosting provider, reactivate to complete the migration."
 
 #: src/view/com/composer/state/video.ts:430
 msgid "Your account is not yet old enough to upload videos. Please try again later."

--- a/src/screens/Deactivated.tsx
+++ b/src/screens/Deactivated.tsx
@@ -143,7 +143,7 @@ export function Deactivated() {
         setError(_(msg`Couldn't reactivate the account. Please try again.`))
       }
 
-      logger.error(e, {
+      logger.error(e instanceof Error ? e : String(e), {
         message: 'Failed to activate account',
       })
     } finally {

--- a/src/screens/Deactivated.tsx
+++ b/src/screens/Deactivated.tsx
@@ -1,30 +1,58 @@
 import {useCallback, useState} from 'react'
 import {View} from 'react-native'
 import {useSafeAreaInsets} from 'react-native-safe-area-context'
+import {AtpAgent, XRPCError} from '@atproto/api'
 import {msg} from '@lingui/core/macro'
 import {useLingui} from '@lingui/react'
 import {Trans} from '@lingui/react/macro'
 import {useQueryClient} from '@tanstack/react-query'
 
 import {useAccountSwitcher} from '#/lib/hooks/useAccountSwitcher'
+import {isNetworkError} from '#/lib/strings/errors'
 import {logger} from '#/logger'
-import {
-  type SessionAccount,
-  useAgent,
-  useSession,
-  useSessionApi,
-} from '#/state/session'
+import {type SessionAccount, useSession, useSessionApi} from '#/state/session'
 import {useLoggedOutViewControls} from '#/state/shell/logged-out'
 import {Logo} from '#/view/icons/Logo'
 import {atoms as a, useTheme} from '#/alf'
 import {AccountList} from '#/components/AccountList'
 import {Button, ButtonIcon, ButtonText} from '#/components/Button'
 import {Divider} from '#/components/Divider'
+import * as TextField from '#/components/forms/TextField'
 import {CircleInfo_Stroke2_Corner0_Rounded as CircleInfo} from '#/components/icons/CircleInfo'
+import {Lock_Stroke2_Corner0_Rounded as Lock} from '#/components/icons/Lock'
 import * as Layout from '#/components/Layout'
 import {Loader} from '#/components/Loader'
 import {Text} from '#/components/Typography'
 import {IS_WEB} from '#/env'
+
+async function reactivateWithPassword({
+  pdsUrl,
+  identifier,
+  password,
+}: {
+  pdsUrl: string
+  identifier: string
+  password: string
+}) {
+  const agent = new AtpAgent({service: pdsUrl})
+  await agent.com.atproto.server.createSession({identifier, password})
+  try {
+    try {
+      await agent.com.atproto.server.activateAccount()
+    } catch (e) {
+      // On retry after a partial success, the account may already be active.
+      // Treat that as a successful no-op so the user isn't stuck.
+      if (e instanceof XRPCError && e.error === 'InvalidRequest') return
+      throw e
+    }
+  } finally {
+    try {
+      await agent.com.atproto.server.deleteSession()
+    } catch {
+      // best-effort cleanup; the throwaway session expires anyway
+    }
+  }
+}
 
 const COL_WIDTH = 400
 
@@ -36,9 +64,9 @@ export function Deactivated() {
   const {onPressSwitchAccount, pendingDid} = useAccountSwitcher()
   const {setShowLoggedOut} = useLoggedOutViewControls()
   const hasOtherAccounts = accounts.length > 1
-  const {logoutCurrentAccount} = useSessionApi()
-  const agent = useAgent()
+  const {logoutCurrentAccount, partialRefreshSession} = useSessionApi()
   const [pending, setPending] = useState(false)
+  const [password, setPassword] = useState('')
   const [error, setError] = useState<string | undefined>()
   const queryClient = useQueryClient()
 
@@ -68,23 +96,51 @@ export function Deactivated() {
   }, [logoutCurrentAccount])
 
   const handleActivate = useCallback(async () => {
+    if (!password.trim()) return
+    if (!currentAccount?.pdsUrl || !currentAccount.handle) {
+      setError(
+        _(msg`Account is missing PDS information. Please sign in again.`),
+      )
+      return
+    }
+    setError(undefined)
+    setPending(true)
     try {
-      setPending(true)
-      await agent.com.atproto.server.activateAccount()
+      await reactivateWithPassword({
+        pdsUrl: currentAccount.pdsUrl,
+        identifier: currentAccount.handle,
+        password,
+      })
+      await partialRefreshSession()
       await queryClient.resetQueries()
-      await agent.resumeSession(agent.session!)
-    } catch (e: any) {
-      switch (e.message) {
-        case 'Bad token scope':
-          setError(
-            _(
-              msg`You're signed in with an App Password. Please sign in with your main password to continue deactivating your account.`,
-            ),
-          )
-          break
-        default:
-          setError(_(msg`Something went wrong, please try again`))
-          break
+      setPassword('')
+    } catch (e: unknown) {
+      if (isNetworkError(e)) {
+        setError(
+          _(
+            msg`Unable to contact your service. Please check your Internet connection.`,
+          ),
+        )
+      } else if (
+        e instanceof XRPCError &&
+        e.error === 'AuthFactorTokenRequired'
+      ) {
+        setError(
+          _(
+            msg`Two-factor authentication is required to reactivate. Please disable 2FA temporarily, or contact support.`,
+          ),
+        )
+      } else if (
+        e instanceof XRPCError &&
+        (e.status === 401 || e.error === 'AuthenticationRequired')
+      ) {
+        setError(_(msg`Incorrect password. Please try again.`))
+      } else if (e instanceof XRPCError && e.status === 429) {
+        setError(
+          _(msg`Too many attempts. Please wait a few minutes and try again.`),
+        )
+      } else {
+        setError(_(msg`Couldn't reactivate the account. Please try again.`))
       }
 
       logger.error(e, {
@@ -93,7 +149,7 @@ export function Deactivated() {
     } finally {
       setPending(false)
     }
-  }, [_, agent, setPending, setError, queryClient])
+  }, [_, currentAccount, password, queryClient, partialRefreshSession])
 
   return (
     <View style={[a.util_screen_outer, a.flex_1]}>
@@ -118,25 +174,47 @@ export function Deactivated() {
             </Text>
             <Text style={[a.text_sm, a.leading_snug]}>
               <Trans>
-                You previously deactivated @{currentAccount?.handle}.
+                @{currentAccount?.handle} is currently deactivated. If you
+                recently moved to a new hosting provider, this is expected —
+                reactivation is the last step to complete the migration.
               </Trans>
             </Text>
             <Text style={[a.text_sm, a.leading_snug, a.pb_md]}>
               <Trans>
-                You can reactivate your account to continue logging in. Your
-                profile and posts will be visible to other users.
+                Reactivating will restore visibility of your profile and posts
+                to other users.
               </Trans>
             </Text>
 
             <View style={[a.gap_sm]}>
+              <View>
+                <TextField.LabelText>
+                  <Trans>Confirm with your account password</Trans>
+                </TextField.LabelText>
+                <TextField.Root>
+                  <TextField.Icon icon={Lock} />
+                  <TextField.Input
+                    label={_(msg`Password`)}
+                    value={password}
+                    onChangeText={setPassword}
+                    secureTextEntry
+                    autoCapitalize="none"
+                    autoComplete="password"
+                    textContentType="password"
+                    editable={!pending}
+                    onSubmitEditing={handleActivate}
+                  />
+                </TextField.Root>
+              </View>
               <Button
                 label={_(msg`Reactivate your account`)}
                 size="large"
                 variant="solid"
                 color="primary"
+                disabled={pending || !password.trim()}
                 onPress={handleActivate}>
                 <ButtonText>
-                  <Trans>Yes, reactivate my account</Trans>
+                  <Trans>Reactivate my account</Trans>
                 </ButtonText>
                 {pending && <ButtonIcon icon={Loader} position="right" />}
               </Button>

--- a/src/screens/Deactivated.tsx
+++ b/src/screens/Deactivated.tsx
@@ -35,7 +35,7 @@ async function reactivateWithPassword({
   password: string
 }) {
   const agent = new AtpAgent({service: pdsUrl})
-  await agent.com.atproto.server.createSession({identifier, password})
+  await agent.login({identifier, password})
   try {
     try {
       await agent.com.atproto.server.activateAccount()
@@ -47,7 +47,7 @@ async function reactivateWithPassword({
     }
   } finally {
     try {
-      await agent.com.atproto.server.deleteSession()
+      await agent.logout()
     } catch {
       // best-effort cleanup; the throwaway session expires anyway
     }

--- a/src/screens/Login/LoginForm.tsx
+++ b/src/screens/Login/LoginForm.tsx
@@ -7,6 +7,10 @@ import {Trans} from '@lingui/react/macro'
 import {cleanError, isNetworkError} from '#/lib/strings/errors'
 import {logger} from '#/logger'
 import {getWebOAuthClient} from '#/state/session/oauth-web-client'
+import {
+  isHandleResolutionError,
+  resolveDeactivatedHandle,
+} from '#/state/session/resolveForLogin'
 import {atoms as a} from '#/alf'
 import {Button, ButtonIcon, ButtonText} from '#/components/Button'
 import {FormError} from '#/components/forms/FormError'
@@ -47,7 +51,13 @@ export const LoginForm = ({
 
     try {
       const client = getWebOAuthClient()
-      await client.signIn(identifier)
+      try {
+        await client.signIn(identifier)
+      } catch (e) {
+        if (!isHandleResolutionError(e)) throw e
+        const did = await resolveDeactivatedHandle(identifier)
+        await client.signIn(did)
+      }
       // Browser will redirect to authorization server
     } catch (e: any) {
       const errMsg = e.toString()

--- a/src/state/session/index.tsx
+++ b/src/state/session/index.tsx
@@ -313,6 +313,8 @@ export function Provider({children}: React.PropsWithChildren<{}>) {
       patch: {
         emailConfirmed: data.emailConfirmed,
         emailAuthFactor: data.emailAuthFactor,
+        active: data.active,
+        status: data.status,
       },
     })
   }, [store, state, cancelPendingTask])

--- a/src/state/session/reducer.ts
+++ b/src/state/session/reducer.ts
@@ -58,7 +58,10 @@ export type Action =
   | {
       type: 'partial-refresh-session'
       accountDid: string
-      patch: Pick<SessionAccount, 'emailConfirmed' | 'emailAuthFactor'>
+      patch: Pick<
+        SessionAccount,
+        'emailConfirmed' | 'emailAuthFactor' | 'active' | 'status'
+      >
     }
 
 function createPublicAgentState(): AgentState {
@@ -257,6 +260,8 @@ let reducer = (state: State, action: Action): State => {
               ...a,
               emailConfirmed: patch.emailConfirmed ?? a.emailConfirmed,
               emailAuthFactor: patch.emailAuthFactor ?? a.emailAuthFactor,
+              active: patch.active,
+              status: patch.status,
             }
           }
           return a

--- a/src/state/session/resolveForLogin.ts
+++ b/src/state/session/resolveForLogin.ts
@@ -1,0 +1,63 @@
+import {AtpAgent, XRPCError} from '@atproto/api'
+
+import {BSKY_SERVICE, PUBLIC_BSKY_SERVICE} from '#/lib/constants'
+import {isNetworkError} from '#/lib/strings/errors'
+
+export function isHandleResolutionError(e: unknown): boolean {
+  if (e && typeof e === 'object' && 'name' in e) {
+    const name = (e as {name?: unknown}).name
+    if (name === 'IdentityResolverError' || name === 'HandleResolverError') {
+      return true
+    }
+  }
+  const s = String(e)
+  return (
+    s.includes('Unable to resolve handle') ||
+    s.includes('does not resolve to a DID') ||
+    s.includes('Failed to resolve identity')
+  )
+}
+
+export async function resolveDeactivatedHandle(
+  identifier: string,
+): Promise<string> {
+  if (identifier.startsWith('did:')) {
+    return identifier
+  }
+  const appview = new AtpAgent({service: PUBLIC_BSKY_SERVICE})
+  let did: string
+  try {
+    const res = await appview.com.atproto.identity.resolveHandle({
+      handle: identifier,
+    })
+    did = res.data.did
+  } catch (e) {
+    if (isNetworkError(e)) throw e
+    throw new Error('Unable to resolve handle')
+  }
+
+  const pds = new AtpAgent({service: BSKY_SERVICE})
+  let active: boolean | undefined
+  let status: string | undefined
+  try {
+    const res = await pds.com.atproto.sync.getRepoStatus({did})
+    active = res.data.active
+    status = res.data.status
+  } catch (e) {
+    if (e instanceof XRPCError && e.status === 404) {
+      return did
+    }
+    if (isNetworkError(e)) throw e
+    throw new Error('Unable to verify account status')
+  }
+  if (active || status === 'deactivated') {
+    return did
+  }
+  if (status === 'takendown') {
+    throw new Error('Account has been taken down')
+  }
+  if (status === 'suspended') {
+    throw new Error('Account has been suspended')
+  }
+  throw new Error('Unable to verify account status')
+}


### PR DESCRIPTION
Two fixes:
1. Support handle resolution during login when an account is deactivated via a fallback to the appview (while still filtering out accounts that are suspended or takendown)
2. Support account reactivation which previously fails because OAuth tokens don't have sufficient scopes to reactivate an account. Do this via asking a user for a password to create a session that's used for reactivation. This session is discarded afterwards