### PR TITLE
fix: restore /support nav, go.blacksky.community shortener, 'What's poppin'?' composer copy

### DIFF
--- a/src/analytics/metrics/types.ts
+++ b/src/analytics/metrics/types.ts
@@ -133,6 +133,7 @@ export type Events = {
       | 'lists'
       | 'saved'
       | 'settings'
+      | 'support'
       | 'menu'
     surface: 'bottomBar' | 'drawer' | 'drawerHeader' | 'topBar' | 'leftNav'
   }

--- a/src/lib/strings/url-helpers.ts
+++ b/src/lib/strings/url-helpers.ts
@@ -361,11 +361,11 @@ export function createProxiedUrl(url: string): string {
     return url
   }
 
-  return `https://go.bsky.app/redirect?u=${encodeURIComponent(url)}`
+  return `https://go.blacksky.community/redirect?u=${encodeURIComponent(url)}`
 }
 
 export function isShortLink(url: string): boolean {
-  return url.startsWith('https://go.bsky.app/')
+  return url.startsWith('https://go.blacksky.community/')
 }
 
 export function shortLinkToHref(url: string): string {

--- a/src/view/com/composer/Composer.tsx
+++ b/src/view/com/composer/Composer.tsx
@@ -1516,7 +1516,7 @@ let ComposerPost = memo(function ComposerPost({
     ? isFirstPost
       ? l`Write your reply`
       : l`Add another post`
-    : l`What's up?`
+    : l`What's poppin'?`
   const discardPromptControl = Prompt.usePromptControl()
 
   const dispatchPost = useCallback(

--- a/src/view/shell/desktop/LeftNav.tsx
+++ b/src/view/shell/desktop/LeftNav.tsx
@@ -58,6 +58,10 @@ import {
   Hashtag_Stroke2_Corner0_Rounded as HashtagIcon,
 } from '#/components/icons/Hashtag'
 import {
+  Heart2_Filled_Stroke2_Corner0_Rounded as HeartFilledIcon,
+  Heart2_Stroke2_Corner0_Rounded as HeartIcon,
+} from '#/components/icons/Heart2'
+import {
   HomeOpen_Filled_Corner0_Rounded as HomeFilledIcon,
   HomeOpen_Stoke2_Corner0_Rounded as HomeIcon,
 } from '#/components/icons/HomeOpen'
@@ -754,6 +758,16 @@ export function DesktopLeftNav({routeName}: {routeName: string}) {
             icons={{
               inactive: SettingsIcon,
               active: SettingsFilledIcon,
+            }}
+          />
+          <NavItem
+            label={l`Support`}
+            href="/support"
+            navItem="support"
+            minimal={leftNavMinimal}
+            icons={{
+              inactive: HeartIcon,
+              active: HeartFilledIcon,
             }}
           />
 


### PR DESCRIPTION
Three Blacksky-branding regressions either introduced by the upstream merge (#104) or pre-existing on main. Verified: pnpm typecheck clean.