### PR TITLE
fix: restore footer link styling + fix 'what is public' link

### DIFF
--- a/src/lib/community/BrandContext.tsx
+++ b/src/lib/community/BrandContext.tsx
@@ -62,6 +62,12 @@ const BLACKSKY_CONFIG: RawCommunityConfig = {
       main: 'https://blacksky.community',
       shortlink: 'https://go.blacksky.community',
     },
+    links: {
+      privacy: 'https://blackskyweb.xyz/about/support/privacy-policy',
+      tos: 'https://www.blackskyweb.xyz/about/support/tos',
+      community: 'https://assembly.blacksky.community/8bbfunvvau',
+      contribute: '/support',
+    },
   },
 }
 

--- a/src/screens/Settings/PrivacyAndSecuritySettings.tsx
+++ b/src/screens/Settings/PrivacyAndSecuritySettings.tsx
@@ -153,7 +153,7 @@ export function PrivacyAndSecuritySettingsScreen({}: Props) {
                       label={_(
                         msg`Learn more about what is public on ${brand.metadata.displayName}.`,
                       )}
-                      to={brand.web.links.privacy}>
+                      to="https://blueskyweb.zendesk.com/hc/en-us/articles/15835264007693-Data-Privacy">
                       <Trans>
                         Learn more about what is public on{' '}
                         {brand.metadata.displayName}.

--- a/src/view/shell/desktop/RightNav.tsx
+++ b/src/view/shell/desktop/RightNav.tsx
@@ -104,6 +104,7 @@ export function DesktopRightNav({routeName}: {routeName: string}) {
           <>
             <InlineLinkText
               to={brand.web.links.contribute}
+              style={[t.atoms.text_contrast_medium]}
               label={_(msg`Support Us`)}>
               {_(msg`Support Us`)}
             </InlineLinkText>
@@ -114,21 +115,31 @@ export function DesktopRightNav({routeName}: {routeName: string}) {
           <>
             <InlineLinkText
               to={brand.web.links.community}
+              style={[t.atoms.text_contrast_medium]}
               label={_(msg`Discussion`)}>
               {_(msg`Discussion`)}
             </InlineLinkText>
             {' \u2022 '}
           </>
         ) : null}
-        <InlineLinkText to={brand.web.links.privacy} label={_(msg`Privacy`)}>
+        <InlineLinkText
+          to={brand.web.links.privacy}
+          style={[t.atoms.text_contrast_medium]}
+          label={_(msg`Privacy`)}>
           {_(msg`Privacy`)}
         </InlineLinkText>
         {' \u2022 '}
-        <InlineLinkText to={brand.web.links.tos} label={_(msg`Terms`)}>
+        <InlineLinkText
+          to={brand.web.links.tos}
+          style={[t.atoms.text_contrast_medium]}
+          label={_(msg`Terms`)}>
           {_(msg`Terms`)}
         </InlineLinkText>
         {' \u2022 '}
-        <InlineLinkText label={_(msg`Help`)} to={HELP_DESK_URL}>
+        <InlineLinkText
+          label={_(msg`Help`)}
+          to={HELP_DESK_URL}
+          style={[t.atoms.text_contrast_medium]}>
           {_(msg`Help`)}
         </InlineLinkText>
       </Text>


### PR DESCRIPTION
Restore the `text_contrast_medium` styling that #107 dropped from the RightNav footer links (they were rendering in primary blue instead of muted gray), and point the "what is public" privacy note to the Zendesk Data-Privacy article. Footer link values (Support Us, Discussion, Privacy, Terms) are fixed separately in Acorn.