### PR TITLE
fix: don't proxy getPreferences/putPreferences to the appview

### DIFF
--- a/src/state/session/agent.ts
+++ b/src/state/session/agent.ts
@@ -350,11 +350,7 @@ class BskyAppAgent extends BskyAgent {
     super({
       service,
       async fetch(...args) {
-        // getPreferences/putPreferences are PDS-local methods. The agent's
-        // global appview proxy header must not reach them, or a PDS whose
-        // default appview differs from ours (e.g. bsky.network) forwards them
-        // to the Blacksky appview, which 501s — breaking the app for accounts
-        // not hosted on the Blacksky PDS.
+        // PDS-local prefs methods must not carry the appview proxy header.
         const input = args[0] as string | URL | Request
         const url =
           typeof input === 'string'

--- a/src/state/session/agent.ts
+++ b/src/state/session/agent.ts
@@ -350,6 +350,30 @@ class BskyAppAgent extends BskyAgent {
     super({
       service,
       async fetch(...args) {
+        // getPreferences/putPreferences are PDS-local methods. The agent's
+        // global appview proxy header must not reach them, or a PDS whose
+        // default appview differs from ours (e.g. bsky.network) forwards them
+        // to the Blacksky appview, which 501s — breaking the app for accounts
+        // not hosted on the Blacksky PDS.
+        const input = args[0] as string | URL | Request
+        const url =
+          typeof input === 'string'
+            ? input
+            : input instanceof URL
+              ? input.href
+              : input.url
+        if (
+          url &&
+          (url.includes('app.bsky.actor.getPreferences') ||
+            url.includes('app.bsky.actor.putPreferences'))
+        ) {
+          const init = args[1] as RequestInit | undefined
+          if (init?.headers) {
+            const headers = new Headers(init.headers)
+            headers.delete('atproto-proxy')
+            init.headers = headers
+          }
+        }
         let success = false
         try {
           const result = await realFetch(...args)


### PR DESCRIPTION
getPreferences/putPreferences are PDS-local, but the agent's global appview proxy header was applied to them, so a PDS whose default appview isn't ours (e.g. bsky.network) forwarded them to the Blacksky appview and got a 501 — breaking app load for accounts not on the Blacksky PDS. Strip the proxy header for these two methods.