### PR TITLE
feat(community-feed): add ComposerPrompt and auto-enable Blacksky-Only on the Community tab

### DIFF
--- a/src/view/com/composer/Composer.tsx
+++ b/src/view/com/composer/Composer.tsx
@@ -105,6 +105,7 @@ import {resolveLinkQueryOptions} from '#/state/queries/resolve-link'
 import {useAgent, useSession} from '#/state/session'
 import {useComposerControls} from '#/state/shell/composer'
 import {type ComposerOpts, type OnPostSuccessData} from '#/state/shell/composer'
+import {useSelectedFeed} from '#/state/shell/selected-feed'
 import {CharProgress} from '#/view/com/composer/char-progress/CharProgress'
 import {ComposerReplyTo} from '#/view/com/composer/ComposerReplyTo'
 import {DraftsButton} from '#/view/com/composer/drafts/DraftsButton'
@@ -361,6 +362,8 @@ export const ComposePost = ({
   const blackskyOnlyDefault = useBlackskyOnlyDefault()
   const setBlackskyOnlyDefault = useSetBlackskyOnlyDefault()
   const {data: isCommunityMember = false} = useCommunityMembership()
+  const selectedFeed = useSelectedFeed()
+  const isCommunityTabActive = selectedFeed === 'community'
 
   // Force Blacksky-Only when the thread targets a community post — replies
   // and quotes of a community post can only land in the community.
@@ -378,9 +381,13 @@ export const ComposePost = ({
       initInteractionSettings: preferences?.postInteractionSettings,
       // Replies inherit their parent's audience: forced on for community
       // parents, forced off for public parents. The sticky default only
-      // applies to top-level posts, and only for community members.
+      // applies to top-level posts, and only for community members. When
+      // the user is composing on the Community tab we also default ON so
+      // the composer matches the tab context; this is per-instance — the
+      // sticky default is left alone (see the toggle's onChange).
       initBlackskyOnly:
         isForcedBlackskyOnly ||
+        (isCommunityTabActive && !replyTo && isCommunityMember) ||
         (!replyTo && isCommunityMember && blackskyOnlyDefault),
     },
     createComposerState,
@@ -1995,6 +2002,8 @@ function ComposerPills({
 }) {
   const t = useTheme()
   const {t: l} = useLingui()
+  const selectedFeed = useSelectedFeed()
+  const isCommunityTabActive = selectedFeed === 'community'
   const {data: isCommunityMember = false} = useCommunityMembership()
   const media = post.embed.media
   const hasMedia =
@@ -2043,7 +2052,12 @@ function ComposerPills({
             onChange={() => {
               const next = !thread.blackskyOnly
               dispatch({type: 'toggle_blacksky_only'})
-              setBlackskyOnlyDefault(next)
+              // On the Community tab the toggle is driven by tab context,
+              // not user choice — keep it per-instance so the sticky
+              // default isn't poisoned by a manual flip.
+              if (!isCommunityTabActive) {
+                setBlackskyOnlyDefault(next)
+              }
             }}
             style={[a.flex_row, a.align_center, a.gap_xs]}>
             <Toggle.LabelText>

--- a/src/view/com/feeds/CommunityFeedPage.tsx
+++ b/src/view/com/feeds/CommunityFeedPage.tsx
@@ -12,6 +12,7 @@ import {
   useCommunityTimelineQuery,
 } from '#/state/queries/community-feed'
 import {useSession} from '#/state/session'
+import {ComposerPrompt} from '#/view/com/feeds/ComposerPrompt'
 import {isThreadChildAt, isThreadParentAt} from '#/view/com/posts/PostFeed'
 import {PostFeedItem} from '#/view/com/posts/PostFeedItem'
 import {ViewFullThread} from '#/view/com/posts/ViewFullThread'
@@ -249,6 +250,7 @@ export function CommunityFeedPage({isPageFocused}: {isPageFocused: boolean}) {
           data={rows}
           renderItem={renderItem}
           keyExtractor={keyExtractor}
+          ListHeaderComponent={hasSession ? <ComposerPrompt /> : null}
           ListEmptyComponent={renderEmpty}
           ListFooterComponent={renderFooter}
           onEndReached={onEndReached}

--- a/src/view/com/feeds/CommunityFeedPage.tsx
+++ b/src/view/com/feeds/CommunityFeedPage.tsx
@@ -124,6 +124,10 @@ export function CommunityFeedPage({isPageFocused}: {isPageFocused: boolean}) {
     }
   }, [refetch])
 
+  const handleRefresh = useCallback(() => {
+    void onRefresh()
+  }, [onRefresh])
+
   useEffect(() => {
     if (isPageFocused) void refetch()
   }, [isPageFocused, refetch])


### PR DESCRIPTION
The Community tab had only the floating compose button — the Following feed's inline "What's popping?" composer prompt was missing, and the composer never reflected the tab context. Surface the prompt as the community feed's list header and have the composer default the Blacksky-Only toggle ON when opened while the Community tab is active. The toggle stays per-instance there: flipping it off doesn't touch the sticky `blackskyOnlyDefault` preference, so users get community-only on the Community tab without affecting their other posts.