### PR TITLE
fix: strip appview proxy header from prefs on the OAuth agent too

### DIFF
--- a/src/state/session/agent.ts
+++ b/src/state/session/agent.ts
@@ -341,6 +341,39 @@ export class Agent extends BaseAgent {
 // WARN: In the factories above, we _manually set a proxy header_ for the agent after we do whatever it is we are supposed to do.
 // Ideally, we wouldn't be doing this. However, since there is so much logic that requires making calls to the PDS right now, it
 // feels safer to just let those run as-is and set the header afterward.
+// app.bsky.actor.getPreferences / putPreferences are PDS-local methods. The
+// agent's global appview proxy header must not reach them: a PDS whose home
+// appview differs from ours (e.g. bsky.network) honors the header and forwards
+// the call to the Blacksky appview, which 501s — breaking app load for any
+// account not hosted on the Blacksky PDS. Strip the header for these methods so
+// the user's own PDS serves them locally. Shared by the session agent and the
+// OAuth agent (both attach the proxy header via configureProxy).
+const PDS_LOCAL_PROXY_EXEMPT_METHODS = [
+  'app.bsky.actor.getPreferences',
+  'app.bsky.actor.putPreferences',
+]
+
+export function stripAppviewProxyForPdsLocalMethods(
+  input: string | URL | Request,
+  init: RequestInit | undefined,
+): RequestInit | undefined {
+  const url =
+    typeof input === 'string'
+      ? input
+      : input instanceof URL
+        ? input.href
+        : input.url
+  if (
+    !url ||
+    !PDS_LOCAL_PROXY_EXEMPT_METHODS.some(method => url.includes(method))
+  ) {
+    return init
+  }
+  const headers = new Headers(init?.headers)
+  headers.delete('atproto-proxy')
+  return {...init, headers}
+}
+
 let realFetch = globalThis.fetch
 class BskyAppAgent extends BskyAgent {
   persistSessionHandler: ((event: AtpSessionEvent) => void) | undefined =
@@ -349,30 +382,11 @@ class BskyAppAgent extends BskyAgent {
   constructor({service}: {service: string}) {
     super({
       service,
-      async fetch(...args) {
-        // PDS-local prefs methods must not carry the appview proxy header.
-        const input = args[0] as string | URL | Request
-        const url =
-          typeof input === 'string'
-            ? input
-            : input instanceof URL
-              ? input.href
-              : input.url
-        if (
-          url &&
-          (url.includes('app.bsky.actor.getPreferences') ||
-            url.includes('app.bsky.actor.putPreferences'))
-        ) {
-          const init = args[1] as RequestInit | undefined
-          if (init?.headers) {
-            const headers = new Headers(init.headers)
-            headers.delete('atproto-proxy')
-            init.headers = headers
-          }
-        }
+      async fetch(input: RequestInfo | URL, init?: RequestInit) {
+        const cleanedInit = stripAppviewProxyForPdsLocalMethods(input, init)
         let success = false
         try {
-          const result = await realFetch(...args)
+          const result = await realFetch(input, cleanedInit)
           success = true
           return result
         } catch (e) {

--- a/src/state/session/oauth-agent.ts
+++ b/src/state/session/oauth-agent.ts
@@ -10,7 +10,10 @@ type OutputSchema = ComAtprotoServerGetSession.OutputSchema
 
 import {BLUESKY_PROXY_HEADER, BSKY_SERVICE} from '#/lib/constants'
 import {logger} from '#/logger'
-import {sessionAccountToSession} from './agent'
+import {
+  sessionAccountToSession,
+  stripAppviewProxyForPdsLocalMethods,
+} from './agent'
 import {configureModerationForAccount} from './moderation'
 import {getWebOAuthClient} from './oauth-web-client'
 import {type SessionAccount} from './types'
@@ -118,7 +121,21 @@ export class OauthBskyAppAgent extends Agent {
   dispatchUrl?: string
 
   constructor(session: OAuthSession) {
-    super(session)
+    // Wrap the OAuth session's fetchHandler so the appview proxy header is
+    // stripped from PDS-local methods. The header is added by the Agent's XRPC
+    // wrapper before it calls the session manager, so stripping here removes it
+    // from the outbound request. See stripAppviewProxyForPdsLocalMethods.
+    super({
+      get did() {
+        return session.did
+      },
+      fetchHandler(url, init) {
+        return session.fetchHandler(
+          url,
+          stripAppviewProxyForPdsLocalMethods(url, init) ?? init,
+        )
+      },
+    })
   }
 
   async prepare(


### PR DESCRIPTION
The earlier fix (7a0c9a33c) stripped the atproto-proxy header from getPreferences/putPreferences only in BskyAppAgent, the app-password session agent. Bluesky-account logins go through OauthBskyAppAgent, which configures the same appview proxy but had no stripping, so getPreferences still carried atproto-proxy to the user's PDS. A PDS whose home appview isn't ours (e.g. bsky.network) honors the header and forwards the call to the Blacksky appview, which 501s MethodNotImplemented — blocking app load for any account not hosted on the Blacksky PDS.

Extract the stripping into a shared stripAppviewProxyForPdsLocalMethods helper and apply it in both agents: BskyAppAgent's fetch and a fetchHandler wrapper around the OAuth session. Both agents attach the proxy via configureProxy, so both need the exception.