### PR TITLE
fix: peer-mod adult-content labels + surface community submit errors

### DIFF
--- a/src/components/moderation/LabelDialog/blackskyLabels.ts
+++ b/src/components/moderation/LabelDialog/blackskyLabels.ts
@@ -172,6 +172,68 @@ export function resolveLabelStrings(
   }
 }
 
+// Global atproto system labels offered alongside the labeler's custom defs.
+// Clients handle these vals natively, so they never appear in a labeler's
+// labelValueDefinitions.
+export const GLOBAL_LABEL_DEFS: ComAtprotoLabelDefs.LabelValueDefinition[] = [
+  {
+    identifier: 'porn',
+    severity: 'none',
+    blurs: 'media',
+    defaultSetting: 'hide',
+    adultOnly: true,
+    locales: [
+      {
+        lang: 'en',
+        name: 'Adult Content',
+        description: 'Explicit sexual images.',
+      },
+    ],
+  },
+  {
+    identifier: 'sexual',
+    severity: 'none',
+    blurs: 'media',
+    defaultSetting: 'warn',
+    adultOnly: true,
+    locales: [
+      {
+        lang: 'en',
+        name: 'Sexually Suggestive',
+        description: 'Does not include nudity.',
+      },
+    ],
+  },
+  {
+    identifier: 'nudity',
+    severity: 'none',
+    blurs: 'media',
+    defaultSetting: 'ignore',
+    adultOnly: false,
+    locales: [
+      {
+        lang: 'en',
+        name: 'Non-sexual Nudity',
+        description: 'E.g. artistic nudes.',
+      },
+    ],
+  },
+  {
+    identifier: 'graphic-media',
+    severity: 'none',
+    blurs: 'media',
+    defaultSetting: 'warn',
+    adultOnly: true,
+    locales: [
+      {
+        lang: 'en',
+        name: 'Graphic Media',
+        description: 'Explicit or potentially disturbing media.',
+      },
+    ],
+  },
+]
+
 /**
  * Returns the Blacksky labeler's label-value definitions, preferring the live
  * set fetched from the labeler service and falling back to the hardcoded set.
@@ -184,8 +246,9 @@ export function useBlackskyLabelDefs(): {
     dids: [BLACKSKY_LABELER],
   })
   const live = data?.[0]?.policies?.labelValueDefinitions
+  const custom = live && live.length ? live : BLACKSKY_LABEL_DEFS_FALLBACK
   return {
-    defs: live && live.length ? live : BLACKSKY_LABEL_DEFS_FALLBACK,
+    defs: [...custom, ...GLOBAL_LABEL_DEFS],
     isLoading,
   }
 }

--- a/src/lib/api/index.ts
+++ b/src/lib/api/index.ts
@@ -369,10 +369,21 @@ async function postCommunity(
         logger.warn(`CID mismatch: local=${cid}, server=${submitData?.cid}`)
       }
     } catch (e) {
+      const serverMessage = e instanceof Error ? e.message : String(e)
       logger.error(`Failed to submit community post content`, {
-        safeMessage: e instanceof Error ? e.message : String(e),
+        safeMessage: serverMessage,
       })
-      throw new Error(t`Failed to submit community post. Please try again.`)
+      // Surface the server's reason (e.g. threadgate/quote restrictions)
+      // instead of a generic failure.
+      const isUserFacing =
+        serverMessage &&
+        !serverMessage.startsWith('HTTP') &&
+        !/InternalServerError|fetch|network/i.test(serverMessage)
+      throw new Error(
+        isUserFacing
+          ? serverMessage
+          : t`Failed to submit community post. Please try again.`,
+      )
     }
 
     // Step 4: Build stub record for PDS with CLIENT-COMPUTED CID


### PR DESCRIPTION
Add the global system labels (Adult Content, Sexually Suggestive, Non-sexual Nudity, Graphic Media) to the peer-mod label picker, and surface the server's rejection reason (e.g. threadgate reply limits) when a community post fails to submit instead of a generic error.