### PR TITLE
brand functionality enhancements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,8 @@ xcuserdata
 DerivedData
 *.hmap
 *.xcuserstate
+.worktrees
+.worktree
 
 # Android/IntelliJ
 #

--- a/src/App.native.tsx
+++ b/src/App.native.tsx
@@ -14,6 +14,7 @@ import {useLingui} from '@lingui/react/macro'
 import * as Sentry from '@sentry/react-native'
 
 import {BrandProvider, useBrand} from '#/lib/community/BrandContext'
+import {CommunityBrandSync} from '#/lib/community/useCommunityBrandSync'
 import {Provider as HideBottomBarBorderProvider} from '#/lib/hooks/useHideBottomBarBorder'
 import {QueryProvider} from '#/lib/react-query'
 import {ThemeProvider} from '#/lib/ThemeContext'
@@ -155,6 +156,7 @@ function InnerApp() {
                           <LabelDefsProvider>
                             <ModerationOptsProvider>
                               <LoggedOutViewProvider>
+                                <CommunityBrandSync />
                                 <SelectedFeedProvider>
                                   <HiddenRepliesProvider>
                                     <HomeBadgeProvider>

--- a/src/env/common.ts
+++ b/src/env/common.ts
@@ -156,6 +156,16 @@ export const LIVE_EVENTS_URL = IS_DEV
   : LIVE_EVENTS_PROD_URL
 
 /**
+ * Base URL of the Acorn brand service. Used on native to resolve a community's
+ * brand config from the active account's PDS (`/brands/resolve?pds=` / `?slug=`).
+ * On web the config is injected by bskyweb (`window.__BRAND_CONFIG__`), so this
+ * is only consulted on native.
+ */
+export const BRAND_SERVICE_URL: string =
+  process.env.EXPO_PUBLIC_BRAND_SERVICE_URL ||
+  'https://brand.acorn.blacksky.community'
+
+/**
  * Stripe publishable key for embedded checkout
  */
 export const STRIPE_PUBLISHABLE_KEY: string =

--- a/src/lib/community/BrandContext.tsx
+++ b/src/lib/community/BrandContext.tsx
@@ -103,15 +103,45 @@ const BLACKSKY_PRIMARY_SCALE = {
   primary_975: '#13133B',
 }
 
+type Pin = {type: string; value: string; pinned: boolean}
+
+// The Following timeline is a protocol-level home invariant, not per-community
+// configurable data. Guarantee exactly one entry (appended if missing) and drop
+// any following entry mis-typed as a feed. Backstops a served config that omits
+// Following (stale cache, service-down fallback, or upstream serialization bug).
+export function ensureFollowingPinned(pins: Pin[]): Pin[] {
+  let hasFollowing = false
+  const out = pins.filter(p => {
+    if (p.type === 'feed' && p.value === 'following') return false // drop corruption
+    if (p.type === 'timeline' && p.value === 'following') {
+      if (hasFollowing) return false // dedupe
+      hasFollowing = true
+    }
+    return true
+  })
+  if (!hasFollowing) out.push({type: 'timeline', value: 'following', pinned: true})
+  return out
+}
+
+function normalizeBrandConfig(config: ComputedBrandConfig): ComputedBrandConfig {
+  return {
+    ...config,
+    feeds: {
+      ...config.feeds,
+      defaultPinned: ensureFollowingPinned(config.feeds?.defaultPinned ?? []),
+    },
+  }
+}
+
 // In multi-brand mode, bskyweb injects the config into the HTML before React loads.
 // In dev mode (yarn web), fall back to the Blacksky defaults above.
 function resolveBrandConfig(): ComputedBrandConfig {
   if (typeof window !== 'undefined' && window.__BRAND_CONFIG__) {
-    return window.__BRAND_CONFIG__
+    return normalizeBrandConfig(window.__BRAND_CONFIG__)
   }
 
   const config = generateComputedConfig(BLACKSKY_CONFIG)
-  return {
+  return normalizeBrandConfig({
     ...config,
     theme: {
       ...config.theme,
@@ -125,7 +155,7 @@ function resolveBrandConfig(): ComputedBrandConfig {
         selectionDark: '#464985',
       },
     },
-  }
+  })
 }
 
 export const DEFAULT_BRAND_CONFIG = resolveBrandConfig()

--- a/src/lib/community/BrandContext.tsx
+++ b/src/lib/community/BrandContext.tsx
@@ -9,6 +9,8 @@ import {
 import {DISCOVER_FEED_URI, VIDEO_FEED_URI} from '#/lib/constants'
 import {DEFAULT_BLUE_HUE} from '#/alf/util/colorGeneration'
 
+const BLACKSKY_MODERATION_DID = 'did:plc:d2mkddsbmnrgr3domzg5qexf'
+
 // Blacksky defaults used as the dev-mode fallback when no brand config is
 // injected by bskyweb (i.e. when running `yarn web` locally).
 const BLACKSKY_CONFIG: RawCommunityConfig = {
@@ -39,6 +41,7 @@ const BLACKSKY_CONFIG: RawCommunityConfig = {
     pds: {
       url: 'https://blacksky.app',
     },
+    moderation: [BLACKSKY_MODERATION_DID],
   },
   feeds: {
     defaultPinned: [

--- a/src/lib/community/BrandContext.tsx
+++ b/src/lib/community/BrandContext.tsx
@@ -1,4 +1,10 @@
-import {createContext, type PropsWithChildren, useContext} from 'react'
+import {
+  createContext,
+  type PropsWithChildren,
+  useCallback,
+  useContext,
+  useState,
+} from 'react'
 
 import {generateComputedConfig} from '#/lib/community/configGenerator'
 import {
@@ -122,11 +128,14 @@ export function ensureFollowingPinned(pins: Pin[]): Pin[] {
     }
     return true
   })
-  if (!hasFollowing) out.push({type: 'timeline', value: 'following', pinned: true})
+  if (!hasFollowing)
+    out.push({type: 'timeline', value: 'following', pinned: true})
   return out
 }
 
-function normalizeBrandConfig(config: ComputedBrandConfig): ComputedBrandConfig {
+function normalizeBrandConfig(
+  config: ComputedBrandConfig,
+): ComputedBrandConfig {
   return {
     ...config,
     feeds: {
@@ -214,18 +223,41 @@ if (typeof document !== 'undefined') {
 }
 
 const BrandContext = createContext<ComputedBrandConfig>(DEFAULT_BRAND_CONFIG)
+const SetBrandContext = createContext<(config: ComputedBrandConfig) => void>(
+  () => {},
+)
 
 export function BrandProvider({
   children,
   config,
 }: PropsWithChildren<{config?: ComputedBrandConfig}>) {
+  // On web the active config is fixed at page load (bskyweb injects it by
+  // hostname), so this state never changes. On native it starts at the bundled
+  // Blacksky default and is updated to follow the active account's community —
+  // see useCommunityBrandSync. Account switches don't remount this provider
+  // (it sits above the account-keyed subtree), so re-theming rides this state.
+  const [current, setCurrent] = useState<ComputedBrandConfig>(
+    config || DEFAULT_BRAND_CONFIG,
+  )
+  const setBrandConfig = useCallback((next: ComputedBrandConfig) => {
+    setCurrent(normalizeBrandConfig(next))
+  }, [])
   return (
-    <BrandContext.Provider value={config || DEFAULT_BRAND_CONFIG}>
-      {children}
-    </BrandContext.Provider>
+    <SetBrandContext.Provider value={setBrandConfig}>
+      <BrandContext.Provider value={current}>{children}</BrandContext.Provider>
+    </SetBrandContext.Provider>
   )
 }
 
 export function useBrand(): ComputedBrandConfig {
   return useContext(BrandContext)
+}
+
+/**
+ * Setter for the active brand config. Used by useCommunityBrandSync (native) to
+ * re-theme when the active account resolves to a different community. The value
+ * is normalized (following-pinned) before it is applied.
+ */
+export function useSetBrandConfig(): (config: ComputedBrandConfig) => void {
+  return useContext(SetBrandContext)
 }

--- a/src/lib/community/__tests__/BrandContext.test.ts
+++ b/src/lib/community/__tests__/BrandContext.test.ts
@@ -26,6 +26,9 @@ describe('BrandContext defaults', () => {
     expect(DEFAULT_BRAND_CONFIG.messages.postButtonLabel).toBe('Post')
 
     expect(DEFAULT_BRAND_CONFIG.services.pds.url).toBe('https://blacksky.app')
+    expect(DEFAULT_BRAND_CONFIG.services.moderation).toEqual([
+      'did:plc:d2mkddsbmnrgr3domzg5qexf',
+    ])
     expect(DEFAULT_BRAND_CONFIG.web.domains.main).toBe(
       'https://blacksky.community',
     )

--- a/src/lib/community/__tests__/BrandContext.test.ts
+++ b/src/lib/community/__tests__/BrandContext.test.ts
@@ -1,7 +1,11 @@
 import {describe, expect, it} from '@jest/globals'
 
 import {DISCOVER_FEED_URI, VIDEO_FEED_URI} from '#/lib/constants'
-import {BRAND_DOMAIN, DEFAULT_BRAND_CONFIG} from '../BrandContext'
+import {
+  BRAND_DOMAIN,
+  DEFAULT_BRAND_CONFIG,
+  ensureFollowingPinned,
+} from '../BrandContext'
 
 describe('BrandContext defaults', () => {
   it('preserves Blacksky defaults when no brand config is injected', () => {
@@ -68,5 +72,41 @@ describe('BrandContext defaults', () => {
     })
     expect(DEFAULT_BRAND_CONFIG.theme.css.selectionLight).toBe('#D2FC51')
     expect(DEFAULT_BRAND_CONFIG.theme.css.selectionDark).toBe('#464985')
+  })
+})
+
+describe('ensureFollowingPinned', () => {
+  it('appends Following when missing, preserving order', () => {
+    const out = ensureFollowingPinned([
+      {type: 'feed', value: 'at://x/medsky', pinned: true},
+    ])
+    expect(out[0]).toEqual({type: 'feed', value: 'at://x/medsky', pinned: true})
+    expect(out[out.length - 1]).toEqual({
+      type: 'timeline',
+      value: 'following',
+      pinned: true,
+    })
+  })
+
+  it('does not duplicate an existing Following entry', () => {
+    const out = ensureFollowingPinned([
+      {type: 'timeline', value: 'following', pinned: true},
+      {type: 'feed', value: 'at://x/medsky', pinned: true},
+    ])
+    expect(
+      out.filter(f => f.type === 'timeline' && f.value === 'following'),
+    ).toHaveLength(1)
+  })
+
+  it('strips a malformed feed-typed following entry', () => {
+    const out = ensureFollowingPinned([
+      {type: 'feed', value: 'following', pinned: true},
+    ])
+    expect(out.some(f => f.type === 'feed' && f.value === 'following')).toBe(
+      false,
+    )
+    expect(
+      out.filter(f => f.type === 'timeline' && f.value === 'following'),
+    ).toHaveLength(1)
   })
 })

--- a/src/lib/community/__tests__/configGenerator.test.ts
+++ b/src/lib/community/__tests__/configGenerator.test.ts
@@ -423,6 +423,24 @@ describe('generateComputedConfig', () => {
     expect(config.services.pds.availableHandles).toEqual([])
   })
 
+  it('passes through moderation service DIDs from raw config', () => {
+    const moderation = ['did:plc:mod1', 'did:plc:mod2']
+    const withModeration: RawCommunityConfig = {
+      ...theinviteConfig,
+      services: {
+        ...theinviteConfig.services,
+        moderation,
+      },
+    }
+    const config = generateComputedConfig(withModeration)
+    expect(config.services.moderation).toEqual(moderation)
+  })
+
+  it('defaults moderation service DIDs to empty array when omitted', () => {
+    const config = generateComputedConfig(theinviteConfig)
+    expect(config.services.moderation).toEqual([])
+  })
+
   it('produces default onboarding config when omitted', () => {
     const config = generateComputedConfig(theinviteConfig)
     expect(config.onboarding.starterPack).toBe('')

--- a/src/lib/community/__tests__/resolveBrand.test.ts
+++ b/src/lib/community/__tests__/resolveBrand.test.ts
@@ -1,0 +1,113 @@
+import {afterEach, beforeEach, describe, expect, it, jest} from '@jest/globals'
+
+import {
+  fetchBrandBySlug,
+  normalizeHost,
+  resolveBrandForAccount,
+  resolveBrandForPds,
+} from '../resolveBrand'
+
+describe('normalizeHost', () => {
+  it('strips scheme, port, path, and lowercases', () => {
+    expect(normalizeHost('https://Blacksky.app')).toBe('blacksky.app')
+    expect(normalizeHost('blacksky.app')).toBe('blacksky.app')
+    expect(normalizeHost('https://blacksky.app:443/xrpc')).toBe('blacksky.app')
+    expect(normalizeHost('http://pds.example.com/')).toBe('pds.example.com')
+    expect(normalizeHost('  https://blacksky.app/  ')).toBe('blacksky.app')
+    expect(normalizeHost('blacksky.app.')).toBe('blacksky.app')
+  })
+})
+
+describe('brand resolution', () => {
+  const makeResponse = (body: unknown, ok = true): Response =>
+    ({ok, json: () => Promise.resolve(body)}) as unknown as Response
+  let fetchMock: jest.MockedFunction<typeof fetch>
+
+  beforeEach(() => {
+    fetchMock = jest
+      .fn<typeof fetch>()
+      .mockResolvedValue(
+        makeResponse({slug: 'x', status: 'published', computed: {slug: 'x'}}),
+      )
+    global.fetch = fetchMock
+  })
+  afterEach(() => {
+    jest.restoreAllMocks()
+  })
+
+  function calledUrl(): string {
+    const arg = fetchMock.mock.calls[0]?.[0]
+    return typeof arg === 'string' ? arg : ''
+  }
+
+  it('fetchBrandBySlug hits ?slug=', async () => {
+    await fetchBrandBySlug('latinsky')
+    expect(calledUrl()).toContain('/brands/resolve?slug=latinsky')
+  })
+
+  it('resolveBrandForPds normalizes the host into ?pds=', async () => {
+    await resolveBrandForPds('https://blacksky.app:443/')
+    expect(calledUrl()).toContain('/brands/resolve?pds=blacksky.app')
+  })
+
+  it('returns null (falls back to default) on non-ok responses', async () => {
+    fetchMock.mockResolvedValueOnce(makeResponse({}, false))
+    expect(await resolveBrandForPds('https://blacksky.app')).toBeNull()
+  })
+
+  it('returns null when fetch throws', async () => {
+    fetchMock.mockRejectedValueOnce(new Error('offline'))
+    expect(await resolveBrandForPds('https://blacksky.app')).toBeNull()
+  })
+
+  describe('resolveBrandForAccount precedence', () => {
+    it('1. stamped communitySlug wins over everything', async () => {
+      await resolveBrandForAccount({
+        communitySlug: 'medsky',
+        pdsUrl: 'https://blacksky.app',
+        handle: 'a.latinsky.app',
+      })
+      expect(calledUrl()).toContain('slug=medsky')
+    })
+
+    it('2. Latinsky carveout: Blacksky PDS + latinsky handle → latinsky slug', async () => {
+      await resolveBrandForAccount({
+        pdsUrl: 'https://blacksky.app',
+        handle: 'alice.latinsky.app',
+      })
+      expect(calledUrl()).toContain('slug=latinsky')
+    })
+
+    it('2b. afrolatinsky handle also triggers the carveout', async () => {
+      await resolveBrandForAccount({
+        pdsUrl: 'https://blacksky.app',
+        handle: 'bob.afrolatinsky.app',
+      })
+      expect(calledUrl()).toContain('slug=latinsky')
+    })
+
+    it('3. plain Blacksky account → null (bundled default), never PDS-resolved', async () => {
+      const result = await resolveBrandForAccount({
+        pdsUrl: 'https://blacksky.app',
+        handle: 'alice.blacksky.app',
+      })
+      expect(result).toBeNull()
+      expect(fetchMock).not.toHaveBeenCalled()
+    })
+
+    it('3b. a latinsky-looking handle on a different PDS is NOT the carveout', async () => {
+      await resolveBrandForAccount({
+        pdsUrl: 'https://pds.example.com',
+        handle: 'evil.latinsky.app',
+      })
+      expect(calledUrl()).toContain('pds=pds.example.com')
+    })
+
+    it('returns null when there is no pdsUrl and no slug', async () => {
+      expect(
+        await resolveBrandForAccount({handle: 'a.blacksky.app'}),
+      ).toBeNull()
+      expect(fetchMock).not.toHaveBeenCalled()
+    })
+  })
+})

--- a/src/lib/community/configGenerator.ts
+++ b/src/lib/community/configGenerator.ts
@@ -387,6 +387,7 @@ export function generateComputedConfig(
         url: raw.services.pds.url,
         availableHandles: raw.services.pds.availableHandles || [],
       },
+      moderation: raw.services.moderation || [],
     },
     web: {
       themeColor: raw.web?.themeColor || primary,

--- a/src/lib/community/resolveBrand.ts
+++ b/src/lib/community/resolveBrand.ts
@@ -1,0 +1,141 @@
+import {DEFAULT_BRAND_CONFIG} from '#/lib/community/BrandContext'
+import {type ComputedBrandConfig} from '#/lib/community/types'
+import {LATINSKY_BRAND_SLUG, LATINSKY_HANDLE_SUFFIXES} from '#/lib/constants'
+import {BRAND_SERVICE_URL} from '#/env'
+
+/**
+ * Minimal shape of a stored account needed to resolve its community brand.
+ * Kept local (rather than importing SessionAccount) so this module stays a pure,
+ * testable leaf with no session dependency.
+ */
+export interface ResolvableAccount {
+  /** The account's PDS URL, e.g. `https://blacksky.app`. */
+  pdsUrl?: string
+  /** The account's handle, e.g. `alice.latinsky.app`. */
+  handle?: string
+  /** Community slug stamped on the account at signup (deterministic fast path). */
+  communitySlug?: string
+}
+
+/**
+ * Normalize a host or URL for equality comparison: lowercase, drop the scheme,
+ * any path/query, the port, and a trailing dot. Mirrors the server-side
+ * `normalize_host` in acorn/brand so both sides agree on what "same host" means.
+ */
+export function normalizeHost(input: string): string {
+  let s = input.trim()
+  const scheme = s.indexOf('://')
+  if (scheme !== -1) s = s.slice(scheme + 3)
+  s = s.split('/')[0]
+  s = s.split('?')[0]
+  s = s.split(':')[0]
+  return s.replace(/\.+$/, '').toLowerCase()
+}
+
+async function fetchResolvedConfig(
+  query: string,
+): Promise<ComputedBrandConfig | null> {
+  try {
+    const res = await fetch(`${BRAND_SERVICE_URL}/brands/resolve?${query}`, {
+      headers: {accept: 'application/json'},
+    })
+    if (!res.ok) return null
+    const data = (await res.json()) as {computed?: ComputedBrandConfig}
+    return data.computed ?? null
+  } catch {
+    return null
+  }
+}
+
+/** Summary of a published brand, as returned by the brand service `GET /brands`. */
+export interface BrandListEntry {
+  slug: string
+  name: string
+  displayName: string
+  themeColor: string
+  logo: string
+  description: string
+  /** The community's PDS URL — signup points at this when the community is picked. */
+  pds: string
+}
+
+/**
+ * List published communities (for the signup community picker). Returns an empty
+ * array when the service is unreachable so callers can fall back to a
+ * Blacksky-only default.
+ */
+export async function fetchBrandList(): Promise<BrandListEntry[]> {
+  try {
+    const res = await fetch(`${BRAND_SERVICE_URL}/brands`, {
+      headers: {accept: 'application/json'},
+    })
+    if (!res.ok) return []
+    const data = (await res.json()) as {brands?: BrandListEntry[]}
+    return data.brands ?? []
+  } catch {
+    return []
+  }
+}
+
+/** Resolve a brand's computed config by community slug. */
+export function fetchBrandBySlug(
+  slug: string,
+): Promise<ComputedBrandConfig | null> {
+  return fetchResolvedConfig(`slug=${encodeURIComponent(slug)}`)
+}
+
+/** Resolve a brand's computed config by the account's PDS host. */
+export function resolveBrandForPds(
+  pdsUrl: string,
+): Promise<ComputedBrandConfig | null> {
+  return fetchResolvedConfig(`pds=${encodeURIComponent(normalizeHost(pdsUrl))}`)
+}
+
+// The default community (Blacksky) owns/shares this PDS and its config is bundled
+// into the app, so the host is taken from the default brand config rather than a
+// separate constant — single source of truth for "the default community's PDS".
+function isBlackskyPds(pdsUrl: string | undefined): boolean {
+  if (!pdsUrl) return false
+  return (
+    normalizeHost(pdsUrl) ===
+    normalizeHost(DEFAULT_BRAND_CONFIG.services.pds.url)
+  )
+}
+
+function isLatinskyHandle(handle: string | undefined): boolean {
+  if (!handle) return false
+  const h = handle.toLowerCase()
+  return LATINSKY_HANDLE_SUFFIXES.some(suffix => h.endsWith(suffix))
+}
+
+/**
+ * Resolve the community brand config for an account. Resolution order:
+ *   1. `communitySlug` stamped at signup — deterministic, and required to
+ *      disambiguate communities that share a PDS.
+ *   2. The Blacksky PDS is the default/shared PDS and is never resolved by PDS:
+ *      - a Latinsky handle on it → Latinsky (the handle carveout);
+ *      - anything else → null (the bundled Blacksky default). Blacksky itself
+ *        has no brand-service config by design.
+ *   3. Any other PDS host → brand (the general case).
+ * Returns `null` when nothing matches or the service is unreachable; callers
+ * fall back to the bundled Blacksky default.
+ */
+export async function resolveBrandForAccount(
+  account: ResolvableAccount,
+): Promise<ComputedBrandConfig | null> {
+  if (account.communitySlug) {
+    return fetchBrandBySlug(account.communitySlug)
+  }
+  if (isBlackskyPds(account.pdsUrl)) {
+    // Shared/default PDS — not PDS-resolvable. Latinsky is identified by handle;
+    // a plain Blacksky account falls through to the bundled default.
+    if (isLatinskyHandle(account.handle)) {
+      return fetchBrandBySlug(LATINSKY_BRAND_SLUG)
+    }
+    return null
+  }
+  if (account.pdsUrl) {
+    return resolveBrandForPds(account.pdsUrl)
+  }
+  return null
+}

--- a/src/lib/community/types.ts
+++ b/src/lib/community/types.ts
@@ -66,6 +66,8 @@ export interface RawCommunityConfig {
       /** Handle domains available for this community (e.g. [".theinvite.us"]) */
       availableHandles?: string[]
     }
+    /** DIDs of moderation services new users should subscribe to */
+    moderation?: string[]
   }
   web?: {
     themeColor?: string
@@ -189,6 +191,8 @@ export interface ComputedBrandConfig {
       /** Handle domains available for this community (e.g. [".theinvite.us"]) */
       availableHandles: string[]
     }
+    /** DIDs of moderation services new users should subscribe to */
+    moderation: string[]
   }
   web: {
     themeColor: string

--- a/src/lib/community/useCommunityBrandSync.ts
+++ b/src/lib/community/useCommunityBrandSync.ts
@@ -1,0 +1,82 @@
+import {useEffect} from 'react'
+
+import {
+  DEFAULT_BRAND_CONFIG,
+  useSetBrandConfig,
+} from '#/lib/community/BrandContext'
+import {resolveBrandForAccount} from '#/lib/community/resolveBrand'
+import {useSession} from '#/state/session'
+import {useLoggedOutView} from '#/state/shell/logged-out'
+import {IS_WEB} from '#/env'
+import {account as accountStorage} from '#/storage'
+
+/**
+ * Keeps the active brand config in sync with the active account (native only).
+ *
+ * Web resolves brand by hostname at page load and never changes it mid-session,
+ * so this is a no-op there. On native there is no hostname signal, so the brand
+ * follows the account: on switch/resume we seed instantly from the per-account
+ * cache (no theme flash) and then reconcile against the brand service.
+ * `useBrand()` consumers (incl. ALF's ThemeProvider) re-render, so the whole app
+ * re-themes without a remount.
+ *
+ * The logged-out surfaces (sign-in / create-account) always show the default
+ * Blacksky brand — including when reached via "add another account" while still
+ * signed in — so we reset to the default whenever the logged-out view is shown
+ * or there is no account.
+ *
+ * Must run inside the session provider (`currentAccount`), the logged-out view
+ * provider (`showLoggedOut`), and below the BrandProvider (the setter).
+ */
+export function useCommunityBrandSync(): void {
+  const {currentAccount} = useSession()
+  const {showLoggedOut} = useLoggedOutView()
+  const setBrandConfig = useSetBrandConfig()
+
+  const did = currentAccount?.did
+  const pdsUrl = currentAccount?.pdsUrl
+  const handle = currentAccount?.handle
+  const communitySlug = currentAccount?.communitySlug
+
+  useEffect(() => {
+    // Web brand is fixed by hostname; this is native-only.
+    if (IS_WEB) return
+
+    // Logged-out surfaces (or no account) always show the default Blacksky brand.
+    // Reset here rather than early-returning so a previous account's theme (or
+    // the community being added) doesn't linger on the sign-in/create screens.
+    if (!did || showLoggedOut) {
+      setBrandConfig(DEFAULT_BRAND_CONFIG)
+      return
+    }
+
+    let cancelled = false
+
+    // 1. Instant seed from the per-account cache (synchronous MMKV).
+    const cached = accountStorage.get([did, 'brandConfig'])
+    if (cached) setBrandConfig(cached)
+
+    // 2. Resolve fresh and reconcile. Null → unreachable/no match; keep the
+    //    seeded (or default) config rather than clobbering it.
+    void resolveBrandForAccount({pdsUrl, handle, communitySlug}).then(
+      config => {
+        if (cancelled || !config) return
+        setBrandConfig(config)
+        accountStorage.set([did, 'brandConfig'], config)
+      },
+    )
+
+    return () => {
+      cancelled = true
+    }
+  }, [did, pdsUrl, handle, communitySlug, showLoggedOut, setBrandConfig])
+}
+
+/**
+ * Renders nothing; drives useCommunityBrandSync. Mounted inside the logged-out
+ * view provider so the hook can read `showLoggedOut`.
+ */
+export function CommunityBrandSync(): null {
+  useCommunityBrandSync()
+  return null
+}

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -11,6 +11,14 @@ export const BSKY_SERVICE = 'https://blacksky.app'
 export const BSKY_SERVICE_DID = 'did:web:bsky.social'
 export const PUBLIC_BSKY_SERVICE = 'https://api.blacksky.community'
 export const DEFAULT_SERVICE = BSKY_SERVICE
+
+// Handle suffixes that identify a Latinsky-community account living on the shared
+// Blacksky PDS. Explicit carveout — not a general resolution mechanism. (The
+// Blacksky PDS host itself is derived from the default brand config; see
+// resolveBrand.ts.)
+export const LATINSKY_HANDLE_SUFFIXES = ['.latinsky.app', '.afrolatinsky.app']
+export const LATINSKY_BRAND_SLUG = 'latinsky'
+
 export const HELP_DESK_URL = `https://docs.blacksky.community/using-blacksky`
 export const CHAT_SERVICE = 'https://api.bsky.chat'
 export const EMBED_SERVICE = 'https://embed.bsky.app'

--- a/src/screens/Onboarding/StepFinished/index.tsx
+++ b/src/screens/Onboarding/StepFinished/index.tsx
@@ -41,6 +41,7 @@ import {
   bulkWriteFollows,
   resolveFollowDids,
   resolveStarterPackUri,
+  subscribeToBrandModerationServices,
 } from '#/screens/Onboarding/util'
 import {atoms as a, useBreakpoints} from '#/alf'
 import {Button, ButtonIcon, ButtonText} from '#/components/Button'
@@ -112,6 +113,7 @@ export function StepFinished() {
             ? {uri: starterPack.uri, cid: starterPack.cid}
             : undefined,
         ),
+        subscribeToBrandModerationServices(agent, agent.session?.did, brand),
         (async () => {
           // Interests need to get saved first, then we can write the feeds to prefs
           await agent.setInterestsPref({tags: selectedInterests})

--- a/src/screens/Onboarding/__tests__/util.test.ts
+++ b/src/screens/Onboarding/__tests__/util.test.ts
@@ -187,25 +187,29 @@ describe('subscribeToBrandModerationServices', () => {
     const brand = makeConfig({}, ['did:plc:mod1', 'did:plc:mod1'])
     const agent = {
       labelers: [] as string[],
-      addLabeler: jest.fn(async (did: string) => {
+      addLabeler: jest.fn((did: string) => {
         agent.labelers.push(did)
       }),
     }
 
-    await subscribeToBrandModerationServices(agent as any, 'did:plc:user', brand)
+    await subscribeToBrandModerationServices(
+      agent as unknown as Parameters<
+        typeof subscribeToBrandModerationServices
+      >[0],
+      'did:plc:user',
+      brand,
+    )
 
     expect(agent.addLabeler).toHaveBeenCalledTimes(1)
     expect(agent.addLabeler).toHaveBeenCalledWith('did:plc:mod1')
-    expect(saveLabelers).toHaveBeenCalledWith('did:plc:user', [
-      'did:plc:mod1',
-    ])
+    expect(saveLabelers).toHaveBeenCalledWith('did:plc:user', ['did:plc:mod1'])
   })
 
   it('keeps onboarding best-effort when a moderation service fails', async () => {
     const brand = makeConfig({}, ['did:plc:good', 'did:plc:bad'])
     const agent = {
       labelers: [] as string[],
-      addLabeler: jest.fn(async (did: string) => {
+      addLabeler: jest.fn((did: string) => {
         if (did === 'did:plc:bad') {
           throw new Error('failed')
         }
@@ -214,12 +218,16 @@ describe('subscribeToBrandModerationServices', () => {
     }
 
     await expect(
-      subscribeToBrandModerationServices(agent as any, 'did:plc:user', brand),
+      subscribeToBrandModerationServices(
+        agent as unknown as Parameters<
+          typeof subscribeToBrandModerationServices
+        >[0],
+        'did:plc:user',
+        brand,
+      ),
     ).resolves.toBeUndefined()
 
     expect(agent.addLabeler).toHaveBeenCalledTimes(2)
-    expect(saveLabelers).toHaveBeenCalledWith('did:plc:user', [
-      'did:plc:good',
-    ])
+    expect(saveLabelers).toHaveBeenCalledWith('did:plc:user', ['did:plc:good'])
   })
 })

--- a/src/screens/Onboarding/__tests__/util.test.ts
+++ b/src/screens/Onboarding/__tests__/util.test.ts
@@ -1,19 +1,32 @@
-import {describe, expect, it} from '@jest/globals'
+import {describe, expect, it, jest} from '@jest/globals'
 
 import {generateComputedConfig} from '#/lib/community/configGenerator'
 import {type RawCommunityConfig} from '#/lib/community/types'
-import {resolveFollowDids, resolveStarterPackUri} from '../util'
+import {saveLabelers} from '#/state/session/agent-config'
+import {
+  resolveFollowDids,
+  resolveModerationServiceDids,
+  resolveStarterPackUri,
+  subscribeToBrandModerationServices,
+} from '../util'
+
+jest.mock('#/state/session/agent-config', () => ({
+  saveLabelers: jest.fn(),
+}))
 
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
 
-function makeConfig(overrides: Partial<RawCommunityConfig['onboarding']> = {}) {
+function makeConfig(
+  overrides: Partial<RawCommunityConfig['onboarding']> = {},
+  moderation: string[] = [],
+) {
   const raw: RawCommunityConfig = {
     metadata: {name: 'Test', displayName: 'Test', slug: 'test'},
     branding: {assets: {}, messages: {}},
     theme: {colors: {primary: '#F2973B'}},
-    services: {pds: {url: 'https://test.example.com'}},
+    services: {pds: {url: 'https://test.example.com'}, moderation},
     onboarding: overrides,
   }
   return generateComputedConfig(raw)
@@ -141,6 +154,72 @@ describe('resolveFollowDids', () => {
       'did:plc:hard',
       'did:plc:config',
       'did:plc:starter',
+    ])
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Brand moderation services
+// ---------------------------------------------------------------------------
+
+describe('resolveModerationServiceDids', () => {
+  it('returns empty array when no moderation services are configured', () => {
+    const brand = makeConfig({})
+    expect(resolveModerationServiceDids(brand)).toEqual([])
+  })
+
+  it('deduplicates and removes empty moderation service DIDs', () => {
+    const brand = makeConfig({}, [
+      'did:plc:mod1',
+      '',
+      'did:plc:mod1',
+      'did:plc:mod2',
+    ])
+    expect(resolveModerationServiceDids(brand)).toEqual([
+      'did:plc:mod1',
+      'did:plc:mod2',
+    ])
+  })
+})
+
+describe('subscribeToBrandModerationServices', () => {
+  it('subscribes to each resolved moderation service and caches labelers', async () => {
+    const brand = makeConfig({}, ['did:plc:mod1', 'did:plc:mod1'])
+    const agent = {
+      labelers: [] as string[],
+      addLabeler: jest.fn(async (did: string) => {
+        agent.labelers.push(did)
+      }),
+    }
+
+    await subscribeToBrandModerationServices(agent as any, 'did:plc:user', brand)
+
+    expect(agent.addLabeler).toHaveBeenCalledTimes(1)
+    expect(agent.addLabeler).toHaveBeenCalledWith('did:plc:mod1')
+    expect(saveLabelers).toHaveBeenCalledWith('did:plc:user', [
+      'did:plc:mod1',
+    ])
+  })
+
+  it('keeps onboarding best-effort when a moderation service fails', async () => {
+    const brand = makeConfig({}, ['did:plc:good', 'did:plc:bad'])
+    const agent = {
+      labelers: [] as string[],
+      addLabeler: jest.fn(async (did: string) => {
+        if (did === 'did:plc:bad') {
+          throw new Error('failed')
+        }
+        agent.labelers.push(did)
+      }),
+    }
+
+    await expect(
+      subscribeToBrandModerationServices(agent as any, 'did:plc:user', brand),
+    ).resolves.toBeUndefined()
+
+    expect(agent.addLabeler).toHaveBeenCalledTimes(2)
+    expect(saveLabelers).toHaveBeenCalledWith('did:plc:user', [
+      'did:plc:good',
     ])
   })
 })

--- a/src/screens/Onboarding/util.ts
+++ b/src/screens/Onboarding/util.ts
@@ -11,6 +11,8 @@ import chunk from 'lodash.chunk'
 
 import {until} from '#/lib/async/until'
 import {type ComputedBrandConfig} from '#/lib/community/types'
+import {logger} from '#/logger'
+import {saveLabelers} from '#/state/session/agent-config'
 
 export async function bulkWriteFollows(
   agent: AtpAgent,
@@ -87,6 +89,51 @@ export function resolveFollowDids(
       ...starterPackMemberDids,
     ]),
   ]
+}
+
+export function resolveModerationServiceDids(
+  brandConfig: ComputedBrandConfig,
+): string[] {
+  return [...new Set((brandConfig.services.moderation || []).filter(Boolean))]
+}
+
+export async function subscribeToBrandModerationServices(
+  agent: AtpAgent,
+  accountDid: string | undefined,
+  brandConfig: ComputedBrandConfig,
+) {
+  const dids = resolveModerationServiceDids(brandConfig)
+  if (!dids.length) return
+
+  const results = await Promise.allSettled(
+    dids.map(async did => {
+      await agent.addLabeler(did)
+      return did
+    }),
+  )
+
+  const subscribedDids = results
+    .map((result, i) => {
+      if (result.status === 'fulfilled') {
+        return result.value
+      }
+      logger.error('Failed to subscribe to brand moderation service', {
+        did: dids[i],
+        safeMessage: result.reason,
+      })
+    })
+    .filter((did): did is string => !!did)
+
+  if (!accountDid || !subscribedDids.length) return
+
+  try {
+    await saveLabelers(
+      accountDid,
+      agent.labelers.length ? [...agent.labelers] : subscribedDids,
+    )
+  } catch (e) {
+    logger.error('Failed to cache brand moderation services', {safeMessage: e})
+  }
 }
 
 async function whenFollowsIndexed(

--- a/src/screens/Signup/StepCommunity/index.tsx
+++ b/src/screens/Signup/StepCommunity/index.tsx
@@ -1,5 +1,5 @@
 import {useMemo} from 'react'
-import {View} from 'react-native'
+import {Image, View} from 'react-native'
 import {msg} from '@lingui/core/macro'
 import {useLingui} from '@lingui/react'
 import {Trans} from '@lingui/react/macro'
@@ -7,25 +7,37 @@ import {useQuery} from '@tanstack/react-query'
 
 import {DEFAULT_BRAND_CONFIG} from '#/lib/community/BrandContext'
 import {fetchBrandList} from '#/lib/community/resolveBrand'
+import {Logo} from '#/view/icons/Logo'
 import {useSignupContext} from '#/screens/Signup/state'
-import {atoms as a} from '#/alf'
+import {atoms as a, useTheme} from '#/alf'
+import {Button} from '#/components/Button'
 import * as TextField from '#/components/forms/TextField'
-import * as Select from '#/components/Select'
+import {CheckThick_Stroke2_Corner0_Rounded as CheckIcon} from '#/components/icons/Check'
 import {Text} from '#/components/Typography'
 import {useAnalytics} from '#/analytics'
 import {BackNextButtons} from '../BackNextButtons'
 
-type CommunityOption = {slug: string; displayName: string; pds: string}
+type CommunityOption = {
+  slug: string
+  displayName: string
+  pds: string
+  logo: string
+  themeColor: string
+  isDefault: boolean
+}
+
+const ICON_SIZE = 48
 
 /**
- * First signup step: choose the community to create the account in. Blacksky is
- * the default and always the first option (its config is bundled into the app,
- * not served by the brand service). Other published communities are listed below
- * it in the dropdown, sourced from the brand service. Selecting one points signup
- * at that community's PDS and stamps its slug so the client can resolve the brand
- * deterministically later.
+ * First signup step: choose the community to create the account in, shown as an
+ * account-switcher-style list (icon + name per row). Blacksky is the default and
+ * always the first option (its config is bundled into the app, not served by the
+ * brand service); other published communities follow, sourced from the brand
+ * service. Selecting one points signup at that community's PDS and stamps its
+ * slug so the client can resolve the brand deterministically later.
  */
 export function StepCommunity({onPressBack}: {onPressBack: () => void}) {
+  const t = useTheme()
   const {_} = useLingui()
   const ax = useAnalytics()
   const {state, dispatch} = useSignupContext()
@@ -36,12 +48,14 @@ export function StepCommunity({onPressBack}: {onPressBack: () => void}) {
     staleTime: 5 * 60 * 1000,
   })
 
-  // Blacksky (the default) always leads; dedupe it out of the served list.
   const options = useMemo<CommunityOption[]>(() => {
     const blacksky: CommunityOption = {
       slug: DEFAULT_BRAND_CONFIG.metadata.slug,
       displayName: DEFAULT_BRAND_CONFIG.metadata.displayName,
       pds: DEFAULT_BRAND_CONFIG.services.pds.url,
+      logo: DEFAULT_BRAND_CONFIG.assets.logo,
+      themeColor: DEFAULT_BRAND_CONFIG.web.themeColor,
+      isDefault: true,
     }
     const others = (brands ?? [])
       .filter(b => b.slug !== blacksky.slug)
@@ -49,18 +63,15 @@ export function StepCommunity({onPressBack}: {onPressBack: () => void}) {
         slug: b.slug,
         displayName: b.displayName || b.name,
         pds: b.pds,
+        logo: b.logo,
+        themeColor: b.themeColor,
+        isDefault: false,
       }))
     return [blacksky, ...others]
   }, [brands])
 
   const selectedSlug =
     state.selectedBrandSlug ?? DEFAULT_BRAND_CONFIG.metadata.slug
-
-  const onValueChange = (slug: string) => {
-    const option = options.find(o => o.slug === slug)
-    if (!option) return
-    dispatch({type: 'setCommunity', slug: option.slug, serviceUrl: option.pds})
-  }
 
   const onNextPress = () => {
     dispatch({type: 'next'})
@@ -80,21 +91,33 @@ export function StepCommunity({onPressBack}: {onPressBack: () => void}) {
           <TextField.LabelText>
             <Trans>Community</Trans>
           </TextField.LabelText>
-          <Select.Root value={selectedSlug} onValueChange={onValueChange}>
-            <Select.Trigger label={_(msg`Select your community`)}>
-              <Select.ValueText placeholder={_(msg`Select your community`)} />
-              <Select.Icon />
-            </Select.Trigger>
-            <Select.Content
-              items={options.map(o => ({label: o.displayName, value: o.slug}))}
-              renderItem={({label, value}) => (
-                <Select.Item value={value} label={label}>
-                  <Select.ItemIndicator />
-                  <Select.ItemText>{label}</Select.ItemText>
-                </Select.Item>
-              )}
-            />
-          </Select.Root>
+          <View
+            style={[
+              a.rounded_lg,
+              a.overflow_hidden,
+              a.border,
+              t.atoms.border_contrast_low,
+            ]}>
+            {options.map((option, i) => (
+              <View key={option.slug}>
+                {i > 0 && (
+                  <View style={[a.border_b, t.atoms.border_contrast_low]} />
+                )}
+                <CommunityItem
+                  option={option}
+                  selected={option.slug === selectedSlug}
+                  onSelect={() =>
+                    dispatch({
+                      type: 'setCommunity',
+                      slug: option.slug,
+                      serviceUrl: option.pds,
+                    })
+                  }
+                  label={_(msg`Create your account in ${option.displayName}`)}
+                />
+              </View>
+            ))}
+          </View>
         </View>
       </View>
       <BackNextButtons
@@ -103,5 +126,98 @@ export function StepCommunity({onPressBack}: {onPressBack: () => void}) {
         onNextPress={onNextPress}
       />
     </>
+  )
+}
+
+function CommunityItem({
+  option,
+  selected,
+  onSelect,
+  label,
+}: {
+  option: CommunityOption
+  selected: boolean
+  onSelect: () => void
+  label: string
+}) {
+  const t = useTheme()
+  return (
+    <Button label={label} onPress={onSelect} style={[a.w_full]}>
+      {({hovered, pressed}) => (
+        <View
+          style={[
+            a.flex_1,
+            a.flex_row,
+            a.align_center,
+            a.p_lg,
+            a.gap_sm,
+            (hovered || pressed) && t.atoms.bg_contrast_25,
+          ]}>
+          <View
+            style={[
+              {width: ICON_SIZE, height: ICON_SIZE},
+              a.rounded_sm,
+              a.overflow_hidden,
+              a.justify_center,
+              a.align_center,
+              t.atoms.bg_contrast_25,
+            ]}>
+            {option.isDefault ? (
+              <Logo width={ICON_SIZE * 0.7} />
+            ) : option.logo ? (
+              <Image
+                accessibilityIgnoresInvertColors
+                source={{uri: option.logo}}
+                style={{width: ICON_SIZE, height: ICON_SIZE}}
+                resizeMode="cover"
+              />
+            ) : (
+              <View
+                style={[
+                  a.flex_1,
+                  a.w_full,
+                  a.justify_center,
+                  a.align_center,
+                  {backgroundColor: option.themeColor},
+                ]}>
+                <Text style={[a.text_lg, a.font_bold, {color: 'white'}]}>
+                  {option.displayName.slice(0, 1).toUpperCase()}
+                </Text>
+              </View>
+            )}
+          </View>
+
+          <View style={[a.flex_1, a.gap_2xs, a.pr_2xl]}>
+            <Text
+              emoji
+              style={[a.font_medium, a.leading_tight, a.text_md]}
+              numberOfLines={1}>
+              {option.displayName}
+            </Text>
+            <Text
+              style={[a.leading_tight, t.atoms.text_contrast_medium, a.text_sm]}
+              numberOfLines={1}>
+              {option.pds.replace(/^https?:\/\//, '')}
+            </Text>
+          </View>
+
+          {selected && (
+            <View
+              style={[
+                {
+                  width: 20,
+                  height: 20,
+                  backgroundColor: t.palette.positive_500,
+                },
+                a.rounded_full,
+                a.justify_center,
+                a.align_center,
+              ]}>
+              <CheckIcon size="xs" style={[{color: t.palette.white}]} />
+            </View>
+          )}
+        </View>
+      )}
+    </Button>
   )
 }

--- a/src/screens/Signup/StepCommunity/index.tsx
+++ b/src/screens/Signup/StepCommunity/index.tsx
@@ -1,0 +1,107 @@
+import {useMemo} from 'react'
+import {View} from 'react-native'
+import {msg} from '@lingui/core/macro'
+import {useLingui} from '@lingui/react'
+import {Trans} from '@lingui/react/macro'
+import {useQuery} from '@tanstack/react-query'
+
+import {DEFAULT_BRAND_CONFIG} from '#/lib/community/BrandContext'
+import {fetchBrandList} from '#/lib/community/resolveBrand'
+import {useSignupContext} from '#/screens/Signup/state'
+import {atoms as a} from '#/alf'
+import * as TextField from '#/components/forms/TextField'
+import * as Select from '#/components/Select'
+import {Text} from '#/components/Typography'
+import {useAnalytics} from '#/analytics'
+import {BackNextButtons} from '../BackNextButtons'
+
+type CommunityOption = {slug: string; displayName: string; pds: string}
+
+/**
+ * First signup step: choose the community to create the account in. Blacksky is
+ * the default and always the first option (its config is bundled into the app,
+ * not served by the brand service). Other published communities are listed below
+ * it in the dropdown, sourced from the brand service. Selecting one points signup
+ * at that community's PDS and stamps its slug so the client can resolve the brand
+ * deterministically later.
+ */
+export function StepCommunity({onPressBack}: {onPressBack: () => void}) {
+  const {_} = useLingui()
+  const ax = useAnalytics()
+  const {state, dispatch} = useSignupContext()
+
+  const {data: brands} = useQuery({
+    queryKey: ['signup-brand-list'],
+    queryFn: fetchBrandList,
+    staleTime: 5 * 60 * 1000,
+  })
+
+  // Blacksky (the default) always leads; dedupe it out of the served list.
+  const options = useMemo<CommunityOption[]>(() => {
+    const blacksky: CommunityOption = {
+      slug: DEFAULT_BRAND_CONFIG.metadata.slug,
+      displayName: DEFAULT_BRAND_CONFIG.metadata.displayName,
+      pds: DEFAULT_BRAND_CONFIG.services.pds.url,
+    }
+    const others = (brands ?? [])
+      .filter(b => b.slug !== blacksky.slug)
+      .map(b => ({
+        slug: b.slug,
+        displayName: b.displayName || b.name,
+        pds: b.pds,
+      }))
+    return [blacksky, ...others]
+  }, [brands])
+
+  const selectedSlug =
+    state.selectedBrandSlug ?? DEFAULT_BRAND_CONFIG.metadata.slug
+
+  const onValueChange = (slug: string) => {
+    const option = options.find(o => o.slug === slug)
+    if (!option) return
+    dispatch({type: 'setCommunity', slug: option.slug, serviceUrl: option.pds})
+  }
+
+  const onNextPress = () => {
+    dispatch({type: 'next'})
+    ax.metric('signup:nextPressed', {activeStep: state.activeStep})
+  }
+
+  return (
+    <>
+      <View style={[a.gap_md, a.pt_lg]}>
+        <Text style={[a.text_md, a.leading_snug]}>
+          <Trans>
+            Choose the community your account will live in. You can always use
+            it across the network.
+          </Trans>
+        </Text>
+        <View style={[a.gap_xs]}>
+          <TextField.LabelText>
+            <Trans>Community</Trans>
+          </TextField.LabelText>
+          <Select.Root value={selectedSlug} onValueChange={onValueChange}>
+            <Select.Trigger label={_(msg`Select your community`)}>
+              <Select.ValueText placeholder={_(msg`Select your community`)} />
+              <Select.Icon />
+            </Select.Trigger>
+            <Select.Content
+              items={options.map(o => ({label: o.displayName, value: o.slug}))}
+              renderItem={({label, value}) => (
+                <Select.Item value={value} label={label}>
+                  <Select.ItemIndicator />
+                  <Select.ItemText>{label}</Select.ItemText>
+                </Select.Item>
+              )}
+            />
+          </Select.Root>
+        </View>
+      </View>
+      <BackNextButtons
+        isLoading={state.isLoading}
+        onBackPress={onPressBack}
+        onNextPress={onNextPress}
+      />
+    </>
+  )
+}

--- a/src/screens/Signup/index.tsx
+++ b/src/screens/Signup/index.tsx
@@ -22,6 +22,7 @@ import {
   useSubmitSignup,
 } from '#/screens/Signup/state'
 import {StepCaptcha} from '#/screens/Signup/StepCaptcha'
+import {StepCommunity} from '#/screens/Signup/StepCommunity'
 import {StepHandle} from '#/screens/Signup/StepHandle'
 import {StepInfo} from '#/screens/Signup/StepInfo'
 import {atoms as a, native, useBreakpoints, useTheme} from '#/alf'
@@ -199,12 +200,14 @@ export function Signup({onPressBack}: {onPressBack: () => void}) {
                         Step {state.activeStep + 1} of{' '}
                         {state.serviceDescription &&
                         !state.serviceDescription.phoneVerificationRequired
-                          ? '2'
-                          : '3'}
+                          ? '3'
+                          : '4'}
                       </Trans>
                     </Text>
                     <Text style={[a.text_3xl, a.font_semi_bold]}>
-                      {state.activeStep === SignupStep.INFO ? (
+                      {state.activeStep === SignupStep.COMMUNITY ? (
+                        <Trans>Choose your community</Trans>
+                      ) : state.activeStep === SignupStep.INFO ? (
                         <Trans>Your account</Trans>
                       ) : state.activeStep === SignupStep.HANDLE ? (
                         <Trans>Choose your username</Trans>
@@ -214,9 +217,11 @@ export function Signup({onPressBack}: {onPressBack: () => void}) {
                     </Text>
                   </View>
 
-                  {state.activeStep === SignupStep.INFO ? (
+                  {state.activeStep === SignupStep.COMMUNITY ? (
+                    <StepCommunity onPressBack={onPressBack} />
+                  ) : state.activeStep === SignupStep.INFO ? (
                     <StepInfo
-                      onPressBack={onPressBack}
+                      onPressBack={() => dispatch({type: 'prev'})}
                       isLoadingStarterPack={
                         isFetchingStarterPack && !isErrorStarterPack
                       }

--- a/src/screens/Signup/state.ts
+++ b/src/screens/Signup/state.ts
@@ -22,6 +22,7 @@ date.setFullYear(date.getFullYear() - 20) // default to 20 years ago
 const DEFAULT_DATE = date
 
 export enum SignupStep {
+  COMMUNITY,
   INFO,
   HANDLE,
   CAPTCHA,
@@ -49,6 +50,8 @@ export type SignupState = {
   serviceUrl: string
   serviceDescription?: ServiceDescription
   userDomain: string
+  /** Slug of the community selected at signup; stamped on the created account. */
+  selectedBrandSlug?: string
   dateOfBirth: Date
   email: string
   password: string
@@ -74,6 +77,7 @@ export type SignupAction =
   | {type: 'finish'}
   | {type: 'setStep'; value: SignupStep}
   | {type: 'setServiceUrl'; value: string}
+  | {type: 'setCommunity'; slug: string; serviceUrl: string}
   | {
       type: 'setServiceDescription'
       value: ServiceDescription | undefined
@@ -95,7 +99,7 @@ export const initialState: SignupState = {
   analytics: undefined,
 
   hasPrev: false,
-  activeStep: SignupStep.INFO,
+  activeStep: SignupStep.COMMUNITY,
   screenTransitionDirection: 'Forward',
 
   serviceUrl: DEFAULT_SERVICE,
@@ -142,7 +146,7 @@ export function reducer(s: SignupState, a: SignupAction): SignupState {
       break
     }
     case 'prev': {
-      if (s.activeStep !== SignupStep.INFO) {
+      if (s.activeStep !== SignupStep.COMMUNITY) {
         next.screenTransitionDirection = 'Backward'
         next.activeStep--
         next.error = ''
@@ -165,6 +169,14 @@ export function reducer(s: SignupState, a: SignupAction): SignupState {
     }
     case 'setServiceUrl': {
       next.serviceUrl = a.value
+      next.userDomain = ''
+      break
+    }
+    case 'setCommunity': {
+      // Selecting a community points signup at that community's PDS; the existing
+      // describeServer pipeline then drives the available handle domains.
+      next.selectedBrandSlug = a.slug
+      next.serviceUrl = a.serviceUrl
       next.userDomain = ''
       break
     }
@@ -254,7 +266,7 @@ export function reducer(s: SignupState, a: SignupAction): SignupState {
     }
   }
 
-  next.hasPrev = next.activeStep !== SignupStep.INFO
+  next.hasPrev = next.activeStep !== SignupStep.COMMUNITY
 
   s.analytics?.logger.debug('signup', next)
 
@@ -342,6 +354,7 @@ export function useSubmitSignup() {
             birthDate: state.dateOfBirth,
             inviteCode: state.inviteCode.trim(),
             verificationCode: state.pendingSubmit?.verificationCode,
+            communitySlug: state.selectedBrandSlug,
           },
           {
             signupDuration: Date.now() - state.signupStartTime,

--- a/src/state/persisted/schema.ts
+++ b/src/state/persisted/schema.ts
@@ -30,6 +30,14 @@ const accountSchema = z.object({
   pdsUrl: z.string().optional(),
   isSelfHosted: z.boolean().optional(),
   isOauthSession: z.boolean().optional(),
+  /**
+   * Slug of the community this account was created in (chosen at signup).
+   * Used on native to deterministically resolve the account's brand — and to
+   * disambiguate communities that share a PDS. Absent for accounts created
+   * before the community picker existed; those fall back to PDS-based
+   * resolution. See src/lib/community/resolveBrand.ts.
+   */
+  communitySlug: z.string().optional(),
 })
 export type PersistedAccount = z.infer<typeof accountSchema>
 

--- a/src/state/session/index.tsx
+++ b/src/state/session/index.tsx
@@ -139,6 +139,12 @@ export function Provider({children}: React.PropsWithChildren<{}>) {
         onAgentSessionChange,
       )
 
+      // Remember which community this account was created in so the client can
+      // resolve its brand deterministically (incl. communities sharing a PDS).
+      if (params.communitySlug) {
+        account.communitySlug = params.communitySlug
+      }
+
       if (signal.aborted) {
         return
       }

--- a/src/state/session/types.ts
+++ b/src/state/session/types.ts
@@ -22,6 +22,8 @@ export type SessionApiContext = {
       inviteCode?: string
       verificationPhone?: string
       verificationCode?: string
+      /** Slug of the community the account is being created in (from signup). */
+      communitySlug?: string
     },
     metrics: Metrics['account:create:success'],
   ) => Promise<void>

--- a/src/storage/schema.ts
+++ b/src/storage/schema.ts
@@ -1,3 +1,4 @@
+import {type ComputedBrandConfig} from '#/lib/community/types'
 import {type Gif} from '#/features/gifPicker/types'
 import {type InviteThemeKey} from '#/features/inviteFriends/themes'
 
@@ -47,4 +48,12 @@ export type Account = {
    * Recently selected GIFs in the GIF picker. Most recent first, capped at 20.
    */
   recentGifs?: Gif[]
+
+  /**
+   * Last resolved community brand config for this account (native only).
+   * Seeded synchronously at boot/account-switch to avoid a Blacksky→community
+   * theme flash, then refreshed from the brand service. See
+   * src/lib/community/useCommunityBrandSync.ts.
+   */
+  brandConfig?: ComputedBrandConfig
 }


### PR DESCRIPTION
1. Follows brand configured labeler on account creation and adds following timeline if omitted from brand configured feeds
2. Adds runtime theming for the mobile apps. Infers brands from the user's PDS and allows selecting a community on sign-up. No explicit community switching functionality - community is tied to account so theming only switches when switching accounts associated with different communities. 