### PR TITLE
feat(composer): use community video embed for community posts

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "blacksky.community",
-  "version": "1.126.1",
+  "version": "1.127.0",
   "private": true,
   "packageManager": "pnpm@11.7.0",
   "engines": {

--- a/src/lib/api/index.ts
+++ b/src/lib/api/index.ts
@@ -277,8 +277,15 @@ async function postCommunity(
     uris.push(uri)
 
     const rt = await rtPromise
-    const embed = await embedPromise
+    const resolvedEmbed = await embedPromise
     const reply = await replyPromise
+
+    // Community posts use the community video embed type, which allows
+    // larger files than app.bsky.embed.video permits.
+    const embed =
+      resolvedEmbed?.$type === 'app.bsky.embed.video'
+        ? {...resolvedEmbed, $type: 'community.blacksky.embed.video'}
+        : resolvedEmbed
 
     // Step 1: Build the canonical record for CID computation
     // This MUST match the structure the appview uses for CID verification


### PR DESCRIPTION
Community posts with video now submit `community.blacksky.embed.video` instead of `app.bsky.embed.video`, lifting the 100MB cap (bsky-owned lexicon) to the 5GB the client already allows. Requires the appview-side union/hydration change in blacksky-algorithms/atproto to be deployed first.