### PR TITLE
fix(app-icon): apply selected icon on iOS instead of resetting to primary

### DIFF
--- a/src/screens/Settings/AppIconSettings/index.tsx
+++ b/src/screens/Settings/AppIconSettings/index.tsx
@@ -88,11 +88,12 @@ export function AppIconSettingsScreen({}: Props) {
 }
 
 function setAppIcon(icon: DynamicAppIcon.IconName) {
-  if (icon === 'default_light') {
-    return getAppIconName(DynamicAppIcon.setAppIcon(null))
-  } else {
-    return getAppIconName(DynamicAppIcon.setAppIcon(icon))
-  }
+  // Every icon shown in this screen (including `default_light`) is registered
+  // as an *alternate* icon by the config plugin — the primary icon is a
+  // separate design. Always apply the selected icon by name so the chosen
+  // variant matches its preview; passing `null` would reset to the primary
+  // icon instead of the legacy light icon.
+  return getAppIconName(DynamicAppIcon.setAppIcon(icon))
 }
 
 function getAppIconName(icon: string | false): DynamicAppIcon.IconName {


### PR DESCRIPTION
The app icon switcher special-cased 'default_light' by calling
setAppIcon(null), which resets to the *primary* app icon. That was
correct upstream where the primary icon was the light design, but
Blacksky's primary icon is now a separate .icon file while
'default_light' is registered as an alternate icon pointing at the
legacy light image. As a result, selecting 'Light' applied the wrong
icon (or appeared to do nothing) rather than the legacy light icon
shown in its preview.

Always apply the selected icon by name so each variant matches its
preview and the radio path agrees with the thumbnail-tap path.