### PR TITLE
Account deletion + Signup fix

### DIFF
--- a/eslint-suppressions.json
+++ b/eslint-suppressions.json
@@ -1459,11 +1459,6 @@
       "count": 1
     }
   },
-  "src/screens/Settings/components/DeleteAccountDialog.tsx": {
-    "@typescript-eslint/no-explicit-any": {
-      "count": 2
-    }
-  },
   "src/screens/Settings/components/DisableEmail2FADialog.tsx": {
     "@typescript-eslint/no-misused-promises": {
       "count": 4

--- a/src/lib/api/gatekeeper.ts
+++ b/src/lib/api/gatekeeper.ts
@@ -79,11 +79,32 @@ export async function gateRequestAccountDelete(params: {
   serviceUrl: string
   did: string
   password: string
-}): Promise<void> {
-  await gatekeeperPost(params.serviceUrl, '/gate/request-account-delete', {
+  authFactorToken?: string
+}): Promise<{status: 'success' | 'authFactorTokenRequired'}> {
+  const body: Record<string, unknown> = {
     did: params.did,
     password: params.password,
-  })
+  }
+  if (params.authFactorToken) {
+    body.authFactorToken = params.authFactorToken
+  }
+
+  try {
+    await gatekeeperPost(
+      params.serviceUrl,
+      '/gate/request-account-delete',
+      body,
+    )
+    return {status: 'success'}
+  } catch (e) {
+    if (
+      e instanceof GatekeeperError &&
+      e.errorType === 'AuthFactorTokenRequired'
+    ) {
+      return {status: 'authFactorTokenRequired'}
+    }
+    throw e
+  }
 }
 
 export async function gateDeactivateAccount(params: {

--- a/src/screens/Settings/components/DeleteAccountDialog.tsx
+++ b/src/screens/Settings/components/DeleteAccountDialog.tsx
@@ -4,8 +4,10 @@ import {msg} from '@lingui/core/macro'
 import {useLingui} from '@lingui/react'
 import {Trans} from '@lingui/react/macro'
 
+import {gateRequestAccountDelete} from '#/lib/api/gatekeeper'
 import {DM_SERVICE_HEADERS} from '#/lib/constants'
 import {useCleanError} from '#/lib/hooks/useCleanError'
+import {useIsBlackskyPds} from '#/lib/hooks/useIsBlackskyPds'
 import {sanitizeHandle} from '#/lib/strings/handles'
 import {logger} from '#/logger'
 import {useAgent, useSession, useSessionApi} from '#/state/session'
@@ -81,7 +83,17 @@ function DeleteAccountDialogInner({
   const [step, setStep] = useState(Step.SEND_CODE)
   const [confirmCode, setConfirmCode] = useState('')
   const [password, setPassword] = useState('')
+  const [authFactorToken, setAuthFactorToken] = useState('')
+  const [authFactorRequired, setAuthFactorRequired] = useState(false)
   const [error, setError] = useState('')
+
+  // OAuth sessions cannot call requestAccountDelete directly (the PDS
+  // requires a full password session), so on gatekeeper-fronted PDSes we
+  // route the request through the gatekeeper, which verifies the password
+  // and mints a session server-side. Same pattern as DeactivateAccountDialog.
+  const isOauth = currentAccount?.isOauthSession === true
+  const isBlackskyPds = useIsBlackskyPds()
+  const useGatekeeper = isOauth && isBlackskyPds
 
   const sendEmail = useCallback(async () => {
     if (emailState === EmailState.PENDING) {
@@ -89,21 +101,53 @@ function DeleteAccountDialogInner({
     }
     try {
       setEmailState(EmailState.PENDING)
-      await agent.com.atproto.server.requestAccountDelete()
+      if (useGatekeeper) {
+        if (!currentAccount?.did || !currentAccount?.service) {
+          throw new Error('Invalid session')
+        }
+        const {status} = await gateRequestAccountDelete({
+          serviceUrl: currentAccount.service,
+          did: currentAccount.did,
+          password,
+          authFactorToken:
+            authFactorToken.replace(WHITESPACE_RE, '') || undefined,
+        })
+        if (status === 'authFactorTokenRequired') {
+          // The PDS has emailed a sign-in code (2FA). Collect it and retry.
+          setAuthFactorRequired(true)
+          setStep(Step.SEND_CODE)
+          setError('')
+          return
+        }
+      } else {
+        await agent.com.atproto.server.requestAccountDelete()
+      }
       setError('')
       setEmailSentCount(prevCount => prevCount + 1)
       setStep(Step.VERIFY_CODE)
-    } catch (e: any) {
-      const {clean, raw} = cleanError(e)
-      const error = clean || raw || e
-      setError(error)
-      logger.error(raw || e, {
-        message: 'Failed to send account deletion verification email',
+    } catch (e: unknown) {
+      if (e instanceof Error && e.message === 'Invalid password') {
+        setError(_(msg`Invalid password. Please try again.`))
+      } else {
+        const {clean, raw} = cleanError(e)
+        setError(clean || raw || String(e))
+      }
+      logger.error('Failed to send account deletion verification email', {
+        error: e,
       })
     } finally {
       setEmailState(EmailState.DEFAULT)
     }
-  }, [agent, cleanError, emailState, setEmailState])
+  }, [
+    _,
+    agent,
+    authFactorToken,
+    cleanError,
+    currentAccount,
+    emailState,
+    password,
+    useGatekeeper,
+  ])
 
   const confirmDeletion = useCallback(async () => {
     try {
@@ -112,12 +156,17 @@ function DeleteAccountDialogInner({
         throw new Error('Invalid did')
       }
       const token = confirmCode.replace(WHITESPACE_RE, '')
-      // Inform chat service of intent to delete account.
-      const {success} = await agent.chat.bsky.actor.deleteAccount(undefined, {
-        headers: DM_SERVICE_HEADERS,
-      })
-      if (!success) {
-        throw new Error('Failed to inform chat service of account deletion')
+      // Inform chat service of intent to delete account. Best-effort: a
+      // failure here (chat service down, account never used chat) must not
+      // block the actual account deletion.
+      try {
+        await agent.chat.bsky.actor.deleteAccount(undefined, {
+          headers: DM_SERVICE_HEADERS,
+        })
+      } catch (e: unknown) {
+        logger.error('Failed to inform chat service of account deletion', {
+          error: e,
+        })
       }
       await agent.com.atproto.server.deleteAccount({
         did: currentAccount.did,
@@ -129,12 +178,11 @@ function DeleteAccountDialogInner({
         resetToTab('HomeTab')
         removeAccount(currentAccount)
       })
-    } catch (e: any) {
+    } catch (e: unknown) {
       const {clean, raw} = cleanError(e)
-      const error = clean || raw || e
-      setError(error)
-      logger.error(raw || e, {
-        message: 'Failed to delete account',
+      setError(clean || raw || String(e))
+      logger.error('Failed to delete account', {
+        error: e,
       })
       setConfirmCode('')
       setPassword('')
@@ -193,10 +241,64 @@ function DeleteAccountDialogInner({
               </Trans>
             </Prompt.DescriptionText>
           </Prompt.Content>
+          {useGatekeeper && (
+            <View style={[a.mb_lg]}>
+              <TextField.LabelText>
+                <Trans>Password</Trans>
+              </TextField.LabelText>
+              <TextField.Root>
+                <TextField.Icon icon={Lock} />
+                <TextField.Input
+                  testID="deleteAccountPasswordInput"
+                  label={_(msg`Enter your password`)}
+                  autoCapitalize="none"
+                  autoCorrect={false}
+                  returnKeyType="done"
+                  secureTextEntry={true}
+                  autoComplete="off"
+                  clearButtonMode="while-editing"
+                  passwordRules={`minlength: ${PASSWORD_MIN_LENGTH}};`}
+                  value={password}
+                  onChangeText={setPassword}
+                  onSubmitEditing={handleSendEmail}
+                />
+              </TextField.Root>
+            </View>
+          )}
+          {useGatekeeper && authFactorRequired && (
+            <View style={[a.mb_lg]}>
+              <TextField.LabelText>
+                <Trans>Sign in code</Trans>
+              </TextField.LabelText>
+              <TokenField
+                value={authFactorToken}
+                onChangeText={setAuthFactorToken}
+                onSubmitEditing={handleSendEmail}
+              />
+              <Text
+                style={[
+                  a.text_sm,
+                  a.leading_snug,
+                  a.mt_xs,
+                  t.atoms.text_contrast_medium,
+                ]}>
+                <Trans>
+                  Your account has two-factor authentication enabled. A sign in
+                  code has been sent to your email address — enter it above,
+                  then press Send email again.
+                </Trans>
+              </Text>
+            </View>
+          )}
           <Prompt.Actions>
             <Prompt.Action
               icon={emailState === EmailState.PENDING ? Loader : Envelope}
               cta={_(msg`Send email`)}
+              disabled={
+                useGatekeeper &&
+                (!isPasswordValid(password) ||
+                  (authFactorRequired && !isValidCode(authFactorToken)))
+              }
               shouldCloseOnPress={false}
               onPress={handleSendEmail}
             />

--- a/src/screens/Signup/index.tsx
+++ b/src/screens/Signup/index.tsx
@@ -1,5 +1,5 @@
 import {useEffect, useReducer, useState} from 'react'
-import {AppState, type AppStateStatus, View} from 'react-native'
+import {AppState, type AppStateStatus, Platform, View} from 'react-native'
 import ReactNativeDeviceAttest from 'react-native-device-attest'
 import Animated, {FadeIn, LayoutAnimationConfig} from 'react-native-reanimated'
 import {AppBskyGraphStarterpack} from '@atproto/api'
@@ -55,12 +55,22 @@ export function Signup({onPressBack}: {onPressBack: () => void}) {
     })
   }, [ax])
 
-  // Use the brand-configured PDS instead of the hardcoded default
+  // Point signup at the brand-configured PDS instead of the hardcoded default.
+  // On web the community is fixed by the hostname (there is no picker step), so
+  // also stamp its slug up front the way the picker would on native.
   useEffect(() => {
     if (brand.services.pds.url) {
-      dispatch({type: 'setServiceUrl', value: brand.services.pds.url})
+      if (Platform.OS === 'web') {
+        dispatch({
+          type: 'setCommunity',
+          slug: brand.metadata.slug,
+          serviceUrl: brand.services.pds.url,
+        })
+      } else {
+        dispatch({type: 'setServiceUrl', value: brand.services.pds.url})
+      }
     }
-  }, [brand.services.pds.url])
+  }, [brand.services.pds.url, brand.metadata.slug])
 
   const activeStarterPack = useActiveStarterPack()
   const {
@@ -146,6 +156,18 @@ export function Signup({onPressBack}: {onPressBack: () => void}) {
     )
   }, [])
 
+  // Web skips the community-picker step, so shift the displayed step numbering
+  // down by one to keep the count starting at "Step 1".
+  const isWeb = Platform.OS === 'web'
+  const stepOffset = isWeb ? 1 : 0
+  const totalSteps =
+    state.serviceDescription &&
+    !state.serviceDescription.phoneVerificationRequired
+      ? 3
+      : 4
+  const displayStep = state.activeStep + 1 - stepOffset
+  const displayTotal = totalSteps - stepOffset
+
   return (
     <Animated.View exiting={native(FadeIn.duration(90))} style={a.flex_1}>
       <SignupContext.Provider value={{state, dispatch}}>
@@ -197,11 +219,7 @@ export function Signup({onPressBack}: {onPressBack: () => void}) {
                     <Text
                       style={[a.font_semi_bold, t.atoms.text_contrast_medium]}>
                       <Trans>
-                        Step {state.activeStep + 1} of{' '}
-                        {state.serviceDescription &&
-                        !state.serviceDescription.phoneVerificationRequired
-                          ? '3'
-                          : '4'}
+                        Step {displayStep} of {displayTotal}
                       </Trans>
                     </Text>
                     <Text style={[a.text_3xl, a.font_semi_bold]}>
@@ -221,7 +239,11 @@ export function Signup({onPressBack}: {onPressBack: () => void}) {
                     <StepCommunity onPressBack={onPressBack} />
                   ) : state.activeStep === SignupStep.INFO ? (
                     <StepInfo
-                      onPressBack={() => dispatch({type: 'prev'})}
+                      onPressBack={
+                        // On web INFO is the first step, so back exits signup;
+                        // on native it returns to the community picker.
+                        isWeb ? onPressBack : () => dispatch({type: 'prev'})
+                      }
                       isLoadingStarterPack={
                         isFetchingStarterPack && !isErrorStarterPack
                       }

--- a/src/screens/Signup/state.ts
+++ b/src/screens/Signup/state.ts
@@ -1,5 +1,5 @@
 import {createContext, useCallback, useContext} from 'react'
-import {LayoutAnimation} from 'react-native'
+import {LayoutAnimation, Platform} from 'react-native'
 import {
   ComAtprotoServerCreateAccount,
   type ComAtprotoServerDescribeServer,
@@ -27,6 +27,14 @@ export enum SignupStep {
   HANDLE,
   CAPTCHA,
 }
+
+/**
+ * On web the community is fixed by the hostname the app is served from, so the
+ * community-picker step is skipped and INFO is the first step. On native the
+ * user chooses their community first. Used as the "floor" step for back/prev.
+ */
+export const FIRST_SIGNUP_STEP =
+  Platform.OS === 'web' ? SignupStep.INFO : SignupStep.COMMUNITY
 
 type SubmitTask = {
   verificationCode: string | undefined
@@ -99,7 +107,7 @@ export const initialState: SignupState = {
   analytics: undefined,
 
   hasPrev: false,
-  activeStep: SignupStep.COMMUNITY,
+  activeStep: FIRST_SIGNUP_STEP,
   screenTransitionDirection: 'Forward',
 
   serviceUrl: DEFAULT_SERVICE,
@@ -146,7 +154,7 @@ export function reducer(s: SignupState, a: SignupAction): SignupState {
       break
     }
     case 'prev': {
-      if (s.activeStep !== SignupStep.COMMUNITY) {
+      if (s.activeStep !== FIRST_SIGNUP_STEP) {
         next.screenTransitionDirection = 'Backward'
         next.activeStep--
         next.error = ''
@@ -266,7 +274,7 @@ export function reducer(s: SignupState, a: SignupAction): SignupState {
     }
   }
 
-  next.hasPrev = next.activeStep !== SignupStep.COMMUNITY
+  next.hasPrev = next.activeStep !== FIRST_SIGNUP_STEP
 
   s.analytics?.logger.debug('signup', next)
 


### PR DESCRIPTION
1. Allow account deletion for OAuth sessions on PDS's fronted by the gatekeeper
2. Only expose community selection on mobile