### PR TITLE
feat: add per-account post-type filters (reposts + quote posts)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -140,3 +140,4 @@ CLAUDE.md
 # superpowers plugin plans/specs — local-only workspace
 docs/superpowers/
 .claude/worktrees
+.worktree/

--- a/__tests__/lib/api/feed-manip.test.ts
+++ b/__tests__/lib/api/feed-manip.test.ts
@@ -1,0 +1,182 @@
+import {describe, expect, it} from '@jest/globals'
+import {
+  type AppBskyActorDefs,
+  type AppBskyFeedDefs,
+} from '@atproto/api'
+
+import {FeedTuner} from '#/lib/api/feed-manip'
+
+function makeAuthor(did: string): AppBskyActorDefs.ProfileViewBasic {
+  return {did, handle: `${did}.test`} as AppBskyActorDefs.ProfileViewBasic
+}
+
+let __postRkeyCounter = 0
+
+function makePostView(opts: {
+  authorDid: string
+  embed?: unknown
+  record?: unknown
+  rkey?: string
+}): AppBskyFeedDefs.PostView {
+  __postRkeyCounter += 1
+  const rkey = opts.rkey ?? `rkey-${__postRkeyCounter}`
+  return {
+    uri: `at://${opts.authorDid}/app.bsky.feed.post/${rkey}`,
+    cid: 'bafyreid',
+    author: makeAuthor(opts.authorDid),
+    record: opts.record ?? {
+      $type: 'app.bsky.feed.post',
+      text: 'hello',
+      createdAt: '2020-01-01T00:00:00.000Z',
+    },
+    indexedAt: '2020-01-01T00:00:00.000Z',
+    embed: opts.embed as AppBskyFeedDefs.PostView['embed'],
+    labels: [],
+    viewer: {threadMuted: false} as AppBskyFeedDefs.PostView['viewer'],
+  } as unknown as AppBskyFeedDefs.PostView
+}
+
+function makeRepost(
+  authorDid: string,
+  reposterDid: string,
+): AppBskyFeedDefs.FeedViewPost {
+  return {
+    post: makePostView({authorDid}),
+    reason: {
+      $type: 'app.bsky.feed.defs#reasonRepost',
+      by: makeAuthor(reposterDid),
+      indexedAt: '2020-01-01T00:00:00.000Z',
+    },
+  } as unknown as AppBskyFeedDefs.FeedViewPost
+}
+
+function makeQuote(
+  authorDid: string,
+  embeddedAuthorDid: string,
+): AppBskyFeedDefs.FeedViewPost {
+  return {
+    post: makePostView({
+      authorDid,
+      embed: {
+        $type: 'app.bsky.embed.record#view',
+        record: {
+          $type: 'app.bsky.embed.record#viewRecord',
+          author: makeAuthor(embeddedAuthorDid),
+          value: {text: 'embedded', $type: 'app.bsky.feed.post'},
+          uri: `at://${embeddedAuthorDid}/app.bsky.feed.post/rkey`,
+          cid: 'bafyreid',
+          indexedAt: '2020-01-01T00:00:00.000Z',
+        },
+      },
+    }),
+  } as unknown as AppBskyFeedDefs.FeedViewPost
+}
+
+function makePlain(authorDid: string): AppBskyFeedDefs.FeedViewPost {
+  return {
+    post: makePostView({authorDid}),
+  } as unknown as AppBskyFeedDefs.FeedViewPost
+}
+
+function postUri(item: AppBskyFeedDefs.FeedViewPost): string {
+  return item.post.uri
+}
+
+describe('FeedTuner.removeAuthorReposts', () => {
+  it('drops only slices whose reason.by.did matches', () => {
+    const feed = [
+      makeRepost('did:plc:author', 'did:plc:blocked'),
+      makeRepost('did:plc:author', 'did:plc:other'),
+      makePlain('did:plc:author'),
+    ]
+    const tuner = new FeedTuner([
+      FeedTuner.removeAuthorReposts({did: 'did:plc:blocked'}),
+    ])
+    const out = tuner.tune(feed, {dryRun: false})
+    expect(out.map(s => postUri(s._feedPost))).toEqual([postUri(feed[1]), postUri(feed[2])])
+  })
+
+  it('preserves order of remaining slices', () => {
+    const a = makeRepost('did:plc:author', 'did:plc:blocked')
+    const b = makeRepost('did:plc:author', 'did:plc:blocked')
+    const c = makeRepost('did:plc:author', 'did:plc:other')
+    const d = makeRepost('did:plc:author', 'did:plc:blocked')
+    const tuner = new FeedTuner([
+      FeedTuner.removeAuthorReposts({did: 'did:plc:blocked'}),
+    ])
+    const out = tuner.tune([a, b, c, d], {dryRun: false})
+    expect(out).toHaveLength(1)
+    expect(out[0]._feedPost).toBe(c)
+  })
+
+  it('does not touch slices with no reason', () => {
+    const a = makePlain('did:plc:author')
+    const b = makePlain('did:plc:author')
+    const tuner = new FeedTuner([
+      FeedTuner.removeAuthorReposts({did: 'did:plc:anyone'}),
+    ])
+    const out = tuner.tune([a, b], {dryRun: false})
+    expect(out).toHaveLength(2)
+  })
+
+  it('composes with removeReposts to drop all reposts', () => {
+    const matched = makeRepost('did:plc:author', 'did:plc:blocked')
+    const other = makeRepost('did:plc:author', 'did:plc:other')
+    const plain = makePlain('did:plc:author')
+    const tuner = new FeedTuner([
+      FeedTuner.removeReposts,
+      FeedTuner.removeAuthorReposts({did: 'did:plc:blocked'}),
+    ])
+    const out = tuner.tune([matched, other, plain], {dryRun: false})
+    expect(out).toHaveLength(1)
+    expect(out[0]._feedPost).toBe(plain)
+  })
+})
+
+describe('FeedTuner.removeAuthorQuotePosts', () => {
+  it('drops only slices whose author.did matches', () => {
+    const blockedQ = makeQuote('did:plc:blocked', 'did:plc:other')
+    const otherQ = makeQuote('did:plc:other', 'did:plc:blocked')
+    const thirdQ = makeQuote('did:plc:third', 'did:plc:author')
+    const tuner = new FeedTuner([
+      FeedTuner.removeAuthorQuotePosts({did: 'did:plc:blocked'}),
+    ])
+    const out = tuner.tune([blockedQ, otherQ, thirdQ], {dryRun: false})
+    expect(out.map(s => postUri(s._feedPost))).toEqual([postUri(otherQ), postUri(thirdQ)])
+  })
+
+  it('preserves order of remaining slices', () => {
+    const a = makeQuote('did:plc:blocked', 'did:plc:x')
+    const b = makeQuote('did:plc:other', 'did:plc:y')
+    const c = makeQuote('did:plc:blocked', 'did:plc:z')
+    const tuner = new FeedTuner([
+      FeedTuner.removeAuthorQuotePosts({did: 'did:plc:blocked'}),
+    ])
+    const out = tuner.tune([a, b, c], {dryRun: false})
+    expect(out).toHaveLength(1)
+    expect(out[0]._feedPost).toBe(b)
+  })
+
+  it('does not touch non-quote slices', () => {
+    const a = makePlain('did:plc:blocked')
+    const b = makePlain('did:plc:blocked')
+    const tuner = new FeedTuner([
+      FeedTuner.removeAuthorQuotePosts({did: 'did:plc:blocked'}),
+    ])
+    const out = tuner.tune([a, b], {dryRun: false})
+    expect(out).toHaveLength(2)
+  })
+
+  it('composes with removeQuotePosts to drop all quotes', () => {
+    const blockedQ = makeQuote('did:plc:blocked', 'did:plc:x')
+    const otherQ = makeQuote('did:plc:other', 'did:plc:y')
+    const plain = makePlain('did:plc:author')
+    const tuner = new FeedTuner([
+      FeedTuner.removeQuotePosts,
+      FeedTuner.removeAuthorQuotePosts({did: 'did:plc:blocked'}),
+    ])
+    const out = tuner.tune([blockedQ, otherQ, plain], {dryRun: false})
+    expect(out).toHaveLength(1)
+    expect(out[0]._feedPost).toBe(plain)
+  })
+})

--- a/src/Navigation.tsx
+++ b/src/Navigation.tsx
@@ -60,6 +60,7 @@ import {FeedsScreen} from '#/view/screens/Feeds'
 import {HomeScreen} from '#/view/screens/Home'
 import {ListsScreen} from '#/view/screens/Lists'
 import {ModerationBlockedAccounts} from '#/view/screens/ModerationBlockedAccounts'
+import {ModerationFilteredAccounts} from '#/view/screens/ModerationFilteredAccounts'
 import {ModerationModlistsScreen} from '#/view/screens/ModerationModlists'
 import {ModerationMutedAccounts} from '#/view/screens/ModerationMutedAccounts'
 import {NotFoundScreen} from '#/view/screens/NotFound'
@@ -198,6 +199,14 @@ function commonScreens(Stack: typeof Flat, unreadCountLabel?: string) {
         name="ModerationBlockedAccounts"
         getComponent={() => ModerationBlockedAccounts}
         options={{title: title(msg`Blocked Accounts`), requireAuth: true}}
+      />
+      <Stack.Screen
+        name="ModerationFilteredAccounts"
+        getComponent={() => ModerationFilteredAccounts}
+        options={{
+          title: title(msg`Filtered Accounts`),
+          requireAuth: true,
+        }}
       />
       <Stack.Screen
         name="ModerationInteractionSettings"

--- a/src/components/PostControls/PostMenu/PostMenuItems.tsx
+++ b/src/components/PostControls/PostMenu/PostMenuItems.tsx
@@ -7,6 +7,8 @@ import {
 } from 'react-native'
 import * as Clipboard from 'expo-clipboard'
 import {
+  AppBskyEmbedRecord,
+  AppBskyEmbedRecordWithMedia,
   type AppBskyFeedDefs,
   type AppBskyFeedPost,
   type AppBskyFeedThreadgate,
@@ -34,6 +36,16 @@ import {type Shadow} from '#/state/cache/post-shadow'
 import {useProfileShadow} from '#/state/cache/profile-shadow'
 import {useFeedFeedbackContext} from '#/state/feed-feedback'
 import {useHiddenPosts, useLanguagePrefs} from '#/state/preferences'
+import {
+  usePostTypeFiltersQuery,
+  useUpdatePostTypeFiltersMutation,
+} from '#/state/queries/post-type-filters'
+import {
+  REPOST_TYPE,
+  QUOTE_TYPES,
+  isQuoteFilter,
+  isRepostFilter,
+} from '#/state/queries/post-type-filters/client-map'
 import {usePinnedPostMutation} from '#/state/queries/pinned-post'
 import {
   usePostDeleteMutation,
@@ -103,6 +115,7 @@ let PostMenuItems = ({
   threadgateRecord,
   onShowLess,
   logContext,
+  viaRepost,
 }: {
   testID: string
   post: Shadow<AppBskyFeedDefs.PostView>
@@ -117,6 +130,7 @@ let PostMenuItems = ({
   threadgateRecord?: AppBskyFeedThreadgate.Record
   onShowLess?: (interaction: AppBskyFeedDefs.Interaction) => void
   logContext: 'FeedItem' | 'PostThreadItem' | 'Post' | 'ImmersiveVideo'
+  viaRepost?: {uri: string; cid: string; by?: {did: string; handle: string}}
 }): React.ReactNode => {
   const {hasSession, currentAccount} = useSession()
   const {t: l} = useLingui()
@@ -171,6 +185,41 @@ let PostMenuItems = ({
 
   const {mutateAsync: toggleQuoteDetachment, isPending: isDetachPending} =
     useToggleQuoteDetachmentMutation()
+
+  const {data: filterRecord} = usePostTypeFiltersQuery()
+  const {mutate: updateFilters} = useUpdatePostTypeFiltersMutation()
+
+  const repostSubject = viaRepost?.by
+  const quoteEmbedForFilter =
+    post.embed && AppBskyEmbedRecord.isView(post.embed) ? post.embed : undefined
+
+  const filterForSubject = (subject: string) =>
+    filterRecord?.filters?.find(f => f.subject === subject)
+
+  const repostSubjectDid = repostSubject?.did
+  const quoteSubjectDid = quoteEmbedForFilter ? postAuthor.did : undefined
+
+  const currentRepostFilter = repostSubjectDid
+    ? filterForSubject(repostSubjectDid)
+    : undefined
+  const currentQuoteFilter = quoteSubjectDid
+    ? filterForSubject(quoteSubjectDid)
+    : undefined
+
+  const isRepostFiltered = isRepostFilter(currentRepostFilter?.types ?? [])
+  const isQuoteFiltered = isQuoteFilter(currentQuoteFilter?.types ?? [])
+
+  const onTogglePostTypeFilter = (
+    subject: string,
+    type: string,
+    shouldAdd: boolean,
+  ) => {
+    updateFilters(
+      shouldAdd
+        ? {op: 'add', subject, type}
+        : {op: 'remove', subject, type},
+    )
+  }
 
   const [queueBlock] = useProfileBlockMutationQueue(postAuthor)
   const [queueMute, queueUnmute] = useProfileMuteMutationQueue(postAuthor)
@@ -626,13 +675,71 @@ let PostMenuItems = ({
           </>
         )}
 
-        {hasSession && (canHideReplyForEveryone || canDetachQuote) && (
-          <>
-            <Menu.Divider />
-            <Menu.Group>
-              {/* canHidePostForMe block removed in fork commit f9c39fb8e —
-                  hide-post-for-me is exposed as a HideButton in PostControls. */}
-              {canHideReplyForEveryone && (
+        {hasSession &&
+          (canHideReplyForEveryone ||
+            canDetachQuote ||
+            !!repostSubject ||
+            !!quoteEmbedForFilter) && (
+            <>
+              <Menu.Divider />
+              <Menu.Group>
+                {/* canHidePostForMe block removed in fork commit f9c39fb8e —
+                    hide-post-for-me is exposed as a HideButton in PostControls. */}
+                {repostSubject && (
+                  <Menu.Item
+                    testID="postDropdownHideRepostFilterBtn"
+                    label={
+                      isRepostFiltered
+                        ? l`Show reposts from @${repostSubject.handle} again`
+                        : l`Don't show reposts from @${repostSubject.handle}`
+                    }
+                    onPress={() =>
+                      onTogglePostTypeFilter(
+                        repostSubject.did,
+                        REPOST_TYPE,
+                        !isRepostFiltered,
+                      )
+                    }>
+                    <Menu.ItemText>
+                      {isRepostFiltered
+                        ? l`Show reposts from @${repostSubject.handle} again`
+                        : l`Don't show reposts from @${repostSubject.handle}`}
+                    </Menu.ItemText>
+                    <Menu.ItemIcon
+                      icon={isRepostFiltered ? Eye : EyeSlash}
+                      position="right"
+                    />
+                  </Menu.Item>
+                )}
+
+                {quoteEmbedForFilter && (
+                  <Menu.Item
+                    testID="postDropdownHideQuoteFilterBtn"
+                    label={
+                      isQuoteFiltered
+                        ? l`Show quote posts from @${postAuthor.handle} again`
+                        : l`Don't show quote posts from @${postAuthor.handle}`
+                    }
+                    onPress={() =>
+                      onTogglePostTypeFilter(
+                        postAuthor.did,
+                        QUOTE_TYPES[0],
+                        !isQuoteFiltered,
+                      )
+                    }>
+                    <Menu.ItemText>
+                      {isQuoteFiltered
+                        ? l`Show quote posts from @${postAuthor.handle} again`
+                        : l`Don't show quote posts from @${postAuthor.handle}`}
+                    </Menu.ItemText>
+                    <Menu.ItemIcon
+                      icon={isQuoteFiltered ? Eye : EyeSlash}
+                      position="right"
+                    />
+                  </Menu.Item>
+                )}
+
+                {canHideReplyForEveryone && (
                 <Menu.Item
                   testID="postDropdownHideBtn"
                   label={

--- a/src/components/PostControls/PostMenu/index.tsx
+++ b/src/components/PostControls/PostMenu/index.tsx
@@ -29,6 +29,7 @@ let PostMenuButton = ({
   onShowLess,
   hitSlop,
   logContext,
+  viaRepost,
 }: {
   testID: string
   post: Shadow<AppBskyFeedDefs.PostView>
@@ -42,6 +43,7 @@ let PostMenuButton = ({
   onShowLess?: (interaction: AppBskyFeedDefs.Interaction) => void
   hitSlop?: Insets
   logContext: 'FeedItem' | 'PostThreadItem' | 'Post' | 'ImmersiveVideo'
+  viaRepost?: {uri: string; cid: string; by?: {did: string; handle: string}}
 }): React.ReactNode => {
   const {t: l} = useLingui()
 
@@ -89,6 +91,7 @@ let PostMenuButton = ({
             threadgateRecord={threadgateRecord}
             onShowLess={onShowLess}
             logContext={logContext}
+            viaRepost={viaRepost}
           />
         )}
       </Menu.Root>

--- a/src/components/PostControls/index.tsx
+++ b/src/components/PostControls/index.tsx
@@ -69,7 +69,7 @@ let PostControls = ({
   logContext: 'FeedItem' | 'PostThreadItem' | 'Post' | 'ImmersiveVideo'
   threadgateRecord?: AppBskyFeedThreadgate.Record
   onShowLess?: (interaction: AppBskyFeedDefs.Interaction) => void
-  viaRepost?: {uri: string; cid: string}
+  viaRepost?: {uri: string; cid: string; by?: {did: string; handle: string}}
   variant?: 'compact' | 'normal' | 'large'
   forceGoogleTranslate?: boolean
 }): React.ReactNode => {
@@ -359,6 +359,7 @@ let PostControls = ({
             left: secondaryControlSpacingStyles.gap / 2,
           }}
           logContext={logContext}
+          viaRepost={viaRepost}
         />
       </View>
     </View>

--- a/src/lib/api/feed-manip.ts
+++ b/src/lib/api/feed-manip.ts
@@ -335,6 +335,28 @@ export class FeedTuner {
     return slices
   }
 
+  static removeAuthorReposts({did}: {did: string}) {
+    return (
+      _tuner: FeedTuner,
+      slices: FeedViewPostsSlice[],
+      _dryRun: boolean,
+    ): FeedViewPostsSlice[] => {
+      for (let i = slices.length - 1; i >= 0; i--) {
+        const reason = slices[i].reason
+        if (AppBskyFeedDefs.isReasonRepost(reason)) {
+          // Predicate narrows but TS over-narrows to `never` on `.$Typed`
+          // unions that include a catch-all arm — cast through the known
+          // upstream ReasonRepost shape.
+          const byDid = (reason as AppBskyFeedDefs.ReasonRepost).by?.did
+          if (byDid === did) {
+            slices.splice(i, 1)
+          }
+        }
+      }
+      return slices
+    }
+  }
+
   static removeQuotePosts(
     tuner: FeedTuner,
     slices: FeedViewPostsSlice[],
@@ -347,6 +369,24 @@ export class FeedTuner {
       }
     }
     return slices
+  }
+
+  static removeAuthorQuotePosts({did}: {did: string}) {
+    return (
+      _tuner: FeedTuner,
+      slices: FeedViewPostsSlice[],
+      _dryRun: boolean,
+    ): FeedViewPostsSlice[] => {
+      for (let i = slices.length - 1; i >= 0; i--) {
+        if (
+          slices[i].isQuotePost &&
+          slices[i].getAuthors().author.did === did
+        ) {
+          slices.splice(i, 1)
+        }
+      }
+      return slices
+    }
   }
 
   static removeOrphans(

--- a/src/lib/routes/types.ts
+++ b/src/lib/routes/types.ts
@@ -13,6 +13,7 @@ export type CommonNavigatorParams = {
   ModerationModlists: undefined
   ModerationMutedAccounts: undefined
   ModerationBlockedAccounts: undefined
+  ModerationFilteredAccounts: undefined
   ModerationInteractionSettings: undefined
   ModerationVerificationSettings: undefined
   Settings: undefined

--- a/src/routes.ts
+++ b/src/routes.ts
@@ -21,6 +21,7 @@ export const router = new Router<AllNavigatableRoutes>({
   ModerationModlists: '/moderation/modlists',
   ModerationMutedAccounts: '/moderation/muted-accounts',
   ModerationBlockedAccounts: '/moderation/blocked-accounts',
+  ModerationFilteredAccounts: '/moderation/filtered-accounts',
   ModerationInteractionSettings: '/moderation/interaction-settings',
   ModerationVerificationSettings: '/moderation/verification-settings',
   // profiles, threads, lists

--- a/src/screens/Moderation/index.tsx
+++ b/src/screens/Moderation/index.tsx
@@ -18,6 +18,7 @@ import {
   type UsePreferencesQueryResponse,
   usePreferencesSetAdultContentMutation,
 } from '#/state/queries/preferences'
+import {usePostTypeFiltersQuery} from '#/state/queries/post-type-filters'
 import {isNonConfigurableModerationAuthority} from '#/state/session/additional-moderation-authorities'
 import {atoms as a, useBreakpoints, useTheme, type ViewStyleProp} from '#/alf'
 import * as Admonition from '#/components/Admonition'
@@ -162,6 +163,8 @@ export function ModerationScreenInner({
     data: labelers,
     error: labelersError,
   } = useMyLabelersQuery()
+  const {data: postTypeFilterRecord} = usePostTypeFiltersQuery()
+  const filteredAccountCount = postTypeFilterRecord?.filters?.length ?? 0
   const {mutateAsync: removeLabelers, isPending: isRemovingLabelers} =
     useRemoveLabelersMutation()
 
@@ -298,6 +301,21 @@ export function ModerationScreenInner({
             <SubItem
               title={_(msg`Blocked accounts`)}
               icon={CircleBanSign}
+              style={[
+                (state.hovered || state.pressed) && [t.atoms.bg_contrast_50],
+              ]}
+            />
+          )}
+        </Link>
+        <Divider />
+        <Link
+          label={_(msg`View your filtered accounts`)}
+          testID="filteredAccountsBtn"
+          to="/moderation/filtered-accounts">
+          {state => (
+            <SubItem
+              title={_(msg`Filtered accounts`)}
+              icon={Filter}
               style={[
                 (state.hovered || state.pressed) && [t.atoms.bg_contrast_50],
               ]}

--- a/src/state/preferences/feed-tuners.tsx
+++ b/src/state/preferences/feed-tuners.tsx
@@ -1,31 +1,37 @@
 import {useMemo} from 'react'
 
-import {FeedTuner} from '#/lib/api/feed-manip'
+import {FeedTuner, type FeedTunerFn} from '#/lib/api/feed-manip'
 import {type FeedDescriptor} from '../queries/post-feed'
 import {usePreferencesQuery} from '../queries/preferences'
 import {useSession} from '../session'
+import {
+  isQuoteFilter,
+  isRepostFilter,
+} from '../queries/post-type-filters/client-map'
+import {usePostTypeFiltersQuery} from '../queries/post-type-filters'
 import {useLanguagePrefs} from './languages'
 
 export function useFeedTuners(feedDesc: FeedDescriptor) {
   const langPrefs = useLanguagePrefs()
   const {data: preferences} = usePreferencesQuery()
+  const {data: postTypeFilters} = usePostTypeFiltersQuery()
   const {currentAccount} = useSession()
 
   return useMemo(() => {
+    let feedTuners: FeedTunerFn[] = []
+
     if (feedDesc.startsWith('author')) {
       if (feedDesc.endsWith('|posts_with_replies')) {
         // TODO: Do this on the server instead.
-        return [FeedTuner.removeReposts]
+        feedTuners = [FeedTuner.removeReposts]
       }
-    }
-    if (feedDesc.startsWith('feedgen')) {
-      return [
+    } else if (feedDesc.startsWith('feedgen')) {
+      feedTuners = [
         FeedTuner.preferredLangOnly(langPrefs.contentLanguages),
         FeedTuner.removeMutedThreads,
       ]
-    }
-    if (feedDesc === 'following' || feedDesc.startsWith('list')) {
-      const feedTuners = [FeedTuner.removeOrphans]
+    } else if (feedDesc === 'following' || feedDesc.startsWith('list')) {
+      feedTuners = [FeedTuner.removeOrphans]
 
       if (preferences?.feedViewPrefs.hideReposts) {
         feedTuners.push(FeedTuner.removeReposts)
@@ -44,9 +50,21 @@ export function useFeedTuners(feedDesc: FeedDescriptor) {
       }
       feedTuners.push(FeedTuner.dedupThreads)
       feedTuners.push(FeedTuner.removeMutedThreads)
-
-      return feedTuners
     }
-    return []
-  }, [feedDesc, currentAccount, preferences, langPrefs])
+
+    // Per-account post-type filters apply to every feed descriptor.
+    // Independent of the PDS-stored feedViewPrefs above (which is global).
+    if (postTypeFilters?.filters) {
+      for (const f of postTypeFilters.filters) {
+        if (isRepostFilter(f.types)) {
+          feedTuners.push(FeedTuner.removeAuthorReposts({did: f.subject}))
+        }
+        if (isQuoteFilter(f.types)) {
+          feedTuners.push(FeedTuner.removeAuthorQuotePosts({did: f.subject}))
+        }
+      }
+    }
+
+    return feedTuners
+  }, [feedDesc, currentAccount, preferences, langPrefs, postTypeFilters])
 }

--- a/src/state/queries/post-type-filters/client-map.test.ts
+++ b/src/state/queries/post-type-filters/client-map.test.ts
@@ -1,0 +1,60 @@
+import {
+  KNOWN_TYPES,
+  QUOTE_TYPES,
+  REPOST_TYPE,
+  isQuoteFilter,
+  isRepostFilter,
+} from './client-map'
+
+const REPOST = 'app.bsky.feed.repost'
+const QUOTE_RECORD = 'app.bsky.embed.record'
+const QUOTE_MEDIA = 'app.bsky.embed.recordWithMedia'
+
+describe('KNOWN_TYPES', () => {
+  it('contains the three expected tokens', () => {
+    expect(KNOWN_TYPES).toEqual(
+      expect.arrayContaining([REPOST, QUOTE_RECORD, QUOTE_MEDIA]),
+    )
+    expect(KNOWN_TYPES).toHaveLength(3)
+  })
+})
+
+describe('REPOST_TYPE', () => {
+  it('is the app.bsky.feed.repost token', () => {
+    expect(REPOST_TYPE).toBe(REPOST)
+  })
+})
+
+describe('QUOTE_TYPES', () => {
+  it('contains both embed variants', () => {
+    expect(QUOTE_TYPES).toEqual([QUOTE_RECORD, QUOTE_MEDIA])
+  })
+})
+
+describe('isRepostFilter', () => {
+  it('returns true when repost token is present', () => {
+    expect(isRepostFilter([REPOST])).toBe(true)
+    expect(isRepostFilter([REPOST, QUOTE_RECORD])).toBe(true)
+  })
+
+  it('returns false when repost token is missing', () => {
+    expect(isRepostFilter([])).toBe(false)
+    expect(isRepostFilter([QUOTE_RECORD])).toBe(false)
+    expect(isRepostFilter([QUOTE_MEDIA])).toBe(false)
+    expect(isRepostFilter([QUOTE_RECORD, QUOTE_MEDIA])).toBe(false)
+  })
+})
+
+describe('isQuoteFilter', () => {
+  it('returns true when either quote token is present', () => {
+    expect(isQuoteFilter([QUOTE_RECORD])).toBe(true)
+    expect(isQuoteFilter([QUOTE_MEDIA])).toBe(true)
+    expect(isQuoteFilter([REPOST, QUOTE_RECORD])).toBe(true)
+    expect(isQuoteFilter([REPOST, QUOTE_MEDIA])).toBe(true)
+  })
+
+  it('returns false when neither quote token is present', () => {
+    expect(isQuoteFilter([])).toBe(false)
+    expect(isQuoteFilter([REPOST])).toBe(false)
+  })
+})

--- a/src/state/queries/post-type-filters/client-map.ts
+++ b/src/state/queries/post-type-filters/client-map.ts
@@ -1,0 +1,32 @@
+// Client-side mapping from the lexicon `$type` tokens to filterable behavior.
+// The lexicon is intentionally token-typed (no coupling to specific record
+// schemas); this file is the source of truth for what each token *means* to
+// the appview client.
+//
+// `KNOWN_TYPES` is derived from preference-feed.json's `knownValues` array so
+// that adding/removing a token in the JSON automatically widens/narrows the
+// `KnownType` union. Adding a new filter behavior still requires a matcher
+// here — that mapping cannot live in the JSON without changing the upstream
+// schema.
+
+import lex from './preference-feed.json'
+
+export const KNOWN_TYPES = lex.defs.authorFilter.properties.types.items
+  .knownValues as readonly string[]
+
+export type KnownType = (typeof KNOWN_TYPES)[number]
+
+export const REPOST_TYPE: KnownType = 'app.bsky.feed.repost'
+
+export const QUOTE_TYPES = [
+  'app.bsky.embed.record',
+  'app.bsky.embed.recordWithMedia',
+] as const satisfies readonly KnownType[]
+
+export function isRepostFilter(types: readonly string[]): boolean {
+  return types.includes(REPOST_TYPE)
+}
+
+export function isQuoteFilter(types: readonly string[]): boolean {
+  return types.some(t => (QUOTE_TYPES as readonly string[]).includes(t))
+}

--- a/src/state/queries/post-type-filters/index.ts
+++ b/src/state/queries/post-type-filters/index.ts
@@ -1,0 +1,127 @@
+import {useMutation, useQuery, useQueryClient} from '@tanstack/react-query'
+
+import {logger} from '#/logger'
+import {STALE} from '#/state/queries'
+import {useAgent, useSession} from '#/state/session'
+
+import {POST_TYPE_FILTER_NSID, type PostTypeFiltersRecord} from './types'
+
+const RQKEY_ROOT = 'post-type-filters'
+
+export const RQKEY = (did: string | undefined) => [
+  RQKEY_ROOT,
+  did ?? '<no-account>',
+]
+
+export type UpdateOp =
+  | {op: 'add'; subject: string; type: string}
+  | {op: 'remove'; subject: string; type: string}
+
+function isRecordNotFoundError(e: unknown): boolean {
+  if (e instanceof Error) {
+    return e.message.includes('Could not locate record:')
+  }
+  return false
+}
+
+export function usePostTypeFiltersQuery() {
+  const {currentAccount} = useSession()
+  const agent = useAgent()
+
+  return useQuery<PostTypeFiltersRecord | null>({
+    queryKey: RQKEY(currentAccount?.did),
+    enabled: !!currentAccount?.did,
+    staleTime: STALE.INFINITY,
+    queryFn: async () => {
+      if (!currentAccount) throw new Error('Not signed in')
+      try {
+        const {data} = await agent.com.atproto.repo.getRecord({
+          repo: currentAccount.did,
+          collection: POST_TYPE_FILTER_NSID,
+          rkey: 'self',
+        })
+        return data.value as PostTypeFiltersRecord
+      } catch (e) {
+        if (isRecordNotFoundError(e)) return null
+        throw e
+      }
+    },
+  })
+}
+
+import {buildRecord} from './serde'
+
+export function useUpdatePostTypeFiltersMutation({
+  onSuccess,
+  onError,
+}: {
+  onSuccess?: () => void
+  onError?: (error: Error) => void
+} = {}) {
+  const queryClient = useQueryClient()
+  const {currentAccount} = useSession()
+  const agent = useAgent()
+
+  type Ctx = {prev: PostTypeFiltersRecord | null}
+
+  return useMutation<void, Error, UpdateOp, Ctx>({
+    mutationFn: async op => {
+      if (!currentAccount) throw new Error('Not signed in')
+      const queryKey = RQKEY(currentAccount.did)
+      const prev =
+        queryClient.getQueryData<PostTypeFiltersRecord | null>(queryKey) ??
+        null
+      const built = buildRecord(prev, op)
+      if (built.action === 'noop') return
+      if (built.action === 'delete') {
+        await agent.com.atproto.repo.deleteRecord({
+          repo: currentAccount.did,
+          collection: POST_TYPE_FILTER_NSID,
+          rkey: 'self',
+        })
+        return
+      }
+      await agent.com.atproto.repo.putRecord({
+        repo: currentAccount.did,
+        collection: POST_TYPE_FILTER_NSID,
+        rkey: 'self',
+        record: built.record,
+      })
+    },
+    onMutate: async op => {
+      if (!currentAccount) return
+      const queryKey = RQKEY(currentAccount.did)
+      await queryClient.cancelQueries({queryKey})
+      const prev =
+        queryClient.getQueryData<PostTypeFiltersRecord | null>(queryKey) ??
+        null
+      const built = buildRecord(prev, op)
+      if (built.action === 'noop') return {prev}
+      queryClient.setQueryData<PostTypeFiltersRecord | null>(
+        queryKey,
+        built.record,
+      )
+      return {prev}
+    },
+    onSuccess: () => {
+      onSuccess?.()
+    },
+    onError: (error, _op, context) => {
+      logger.error('Failed to update post-type filters', {safeMessage: error})
+      if (currentAccount && context) {
+        queryClient.setQueryData<PostTypeFiltersRecord | null>(
+          RQKEY(currentAccount.did),
+          context.prev,
+        )
+      }
+      onError?.(error)
+    },
+    onSettled: () => {
+      if (currentAccount) {
+        void queryClient.invalidateQueries({
+          queryKey: RQKEY(currentAccount.did),
+        })
+      }
+    },
+  })
+}

--- a/src/state/queries/post-type-filters/preference-feed.json
+++ b/src/state/queries/post-type-filters/preference-feed.json
@@ -1,0 +1,60 @@
+{
+  "lexicon": 1,
+  "id": "community.lexicon.preference.feed",
+  "description": "Per-author post-type filters. The viewer declares that records of specific $type values authored by specific accounts should be hidden from their feeds. The client is responsible for mapping the $type tokens to filterable behavior; the lexicon is intentionally token-typed for interop safety without coupling to specific record schemas.",
+  "defs": {
+    "main": {
+      "type": "record",
+      "key": "literal:self",
+      "record": {
+        "type": "object",
+        "required": ["filters"],
+        "properties": {
+          "filters": {
+            "type": "array",
+            "maxLength": 5000,
+            "items": {"type": "ref", "ref": "#authorFilter"}
+          },
+          "updatedAt": {
+            "type": "string",
+            "format": "datetime",
+            "description": "Timestamp of the most recent change to any filter."
+          }
+        }
+      }
+    },
+    "authorFilter": {
+      "type": "object",
+      "description": "A filter that hides records of the listed $type tokens when authored by the given DID.",
+      "required": ["subject", "types"],
+      "properties": {
+        "subject": {
+          "type": "string",
+          "format": "did",
+          "description": "DID of the author whose records this filter applies to."
+        },
+        "types": {
+          "type": "array",
+          "minLength": 1,
+          "items": {
+            "type": "string",
+            "knownValues": [
+              "app.bsky.feed.repost",
+              "app.bsky.embed.record",
+              "app.bsky.embed.recordWithMedia"
+            ]
+          },
+          "description": "ATProto $type tokens to hide when the author matches `subject`."
+        },
+        "createdAt": {
+          "type": "string",
+          "format": "datetime"
+        },
+        "updatedAt": {
+          "type": "string",
+          "format": "datetime"
+        }
+      }
+    }
+  }
+}

--- a/src/state/queries/post-type-filters/serde.test.ts
+++ b/src/state/queries/post-type-filters/serde.test.ts
@@ -1,0 +1,168 @@
+import {addFilter, buildRecord, removeFilter} from './serde'
+import {POST_TYPE_FILTER_NSID, type PostTypeFiltersRecord} from './types'
+
+const NOW = '2026-05-05T12:00:00.000Z'
+const EARLIER = '2026-04-01T00:00:00.000Z'
+const SUBJECT_A = 'did:plc:aaa'
+const SUBJECT_B = 'did:plc:bbb'
+const REPOST = 'app.bsky.feed.repost'
+const QUOTE = 'app.bsky.embed.record'
+const QUOTE_MEDIA = 'app.bsky.embed.recordWithMedia'
+
+function emptyRecord(): PostTypeFiltersRecord {
+  return {$type: POST_TYPE_FILTER_NSID, filters: []}
+}
+
+describe('addFilter', () => {
+  it('creates a new entry when subject is unseen', () => {
+    const next = addFilter(undefined, SUBJECT_A, REPOST, NOW)
+    expect(next).toEqual([
+      {subject: SUBJECT_A, types: [REPOST], createdAt: NOW, updatedAt: NOW},
+    ])
+  })
+
+  it('appends to the existing entry without re-stamping createdAt', () => {
+    const start = addFilter(undefined, SUBJECT_A, REPOST, EARLIER)
+    const next = addFilter(start, SUBJECT_A, QUOTE, NOW)
+    expect(next).toEqual([
+      {
+        subject: SUBJECT_A,
+        types: [REPOST, QUOTE],
+        createdAt: EARLIER,
+        updatedAt: NOW,
+      },
+    ])
+  })
+
+  it('is idempotent for an existing type', () => {
+    const start = addFilter(undefined, SUBJECT_A, REPOST, EARLIER)
+    const next = addFilter(start, SUBJECT_A, REPOST, NOW)
+    expect(next).toBe(start)
+  })
+
+  it('dedupes if asked to add a token already present', () => {
+    const start = addFilter(undefined, SUBJECT_A, REPOST, EARLIER)
+    const next = addFilter(start, SUBJECT_A, REPOST, NOW)
+    expect(next[0].types).toEqual([REPOST])
+  })
+
+  it('ignores unknown $type tokens', () => {
+    const next = addFilter(undefined, SUBJECT_A, 'app.example.unknown', NOW)
+    expect(next).toEqual([])
+  })
+})
+
+describe('removeFilter', () => {
+  it('drops the entry entirely when the last type is removed', () => {
+    const start = [
+      {subject: SUBJECT_A, types: [REPOST], createdAt: EARLIER, updatedAt: EARLIER},
+    ]
+    const next = removeFilter(start, SUBJECT_A, REPOST)
+    expect(next).toEqual([])
+  })
+
+  it('keeps the entry when other types remain', () => {
+    const start = [
+      {
+        subject: SUBJECT_A,
+        types: [REPOST, QUOTE],
+        createdAt: EARLIER,
+        updatedAt: EARLIER,
+      },
+    ]
+    const next = removeFilter(start, SUBJECT_A, REPOST)
+    expect(next).toEqual([
+      {subject: SUBJECT_A, types: [QUOTE], createdAt: EARLIER, updatedAt: EARLIER},
+    ])
+  })
+
+  it('is a no-op when the subject is not present', () => {
+    const start = [
+      {subject: SUBJECT_A, types: [REPOST], createdAt: EARLIER, updatedAt: EARLIER},
+    ]
+    const next = removeFilter(start, SUBJECT_B, REPOST)
+    expect(next).toBe(start)
+  })
+
+  it('is a no-op when the type is not on that subject', () => {
+    const start = [
+      {subject: SUBJECT_A, types: [REPOST], createdAt: EARLIER, updatedAt: EARLIER},
+    ]
+    const next = removeFilter(start, SUBJECT_A, QUOTE)
+    expect(next).toBe(start)
+  })
+
+  it('returns [] when called with no prev', () => {
+    expect(removeFilter(null, SUBJECT_A, REPOST)).toEqual([])
+    expect(removeFilter(undefined, SUBJECT_A, REPOST)).toEqual([])
+  })
+})
+
+describe('buildRecord', () => {
+  it('returns a put record with $type and updatedAt', () => {
+    const prev: PostTypeFiltersRecord = {
+      $type: POST_TYPE_FILTER_NSID,
+      filters: [
+        {
+          subject: SUBJECT_A,
+          types: [REPOST],
+          createdAt: EARLIER,
+          updatedAt: EARLIER,
+        },
+      ],
+    }
+    const result = buildRecord(prev, {op: 'add', subject: SUBJECT_A, type: QUOTE}, NOW)
+    expect(result.action).toBe('put')
+    expect(result.record.$type).toBe(POST_TYPE_FILTER_NSID)
+    expect(result.record.updatedAt).toBe(NOW)
+    expect(result.record.filters).toHaveLength(1)
+    expect(result.record.filters[0].types).toEqual([REPOST, QUOTE])
+  })
+
+  it('returns a delete action when the last filter is removed', () => {
+    const prev: PostTypeFiltersRecord = {
+      $type: POST_TYPE_FILTER_NSID,
+      filters: [
+        {subject: SUBJECT_A, types: [REPOST], createdAt: EARLIER, updatedAt: EARLIER},
+      ],
+    }
+    const result = buildRecord(prev, {op: 'remove', subject: SUBJECT_A, type: REPOST}, NOW)
+    expect(result.action).toBe('delete')
+  })
+
+  it('returns a noop action when prev is null and the result list is empty', () => {
+    const result = buildRecord(
+      null,
+      {op: 'remove', subject: SUBJECT_A, type: REPOST},
+      NOW,
+    )
+    expect(result.action).toBe('noop')
+  })
+
+  it('produces a fresh record on add with no prev', () => {
+    const result = buildRecord(
+      emptyRecord(),
+      {op: 'add', subject: SUBJECT_A, type: REPOST},
+      NOW,
+    )
+    expect(result.action).toBe('put')
+    expect(result.record.filters).toEqual([
+      {subject: SUBJECT_A, types: [REPOST], createdAt: NOW, updatedAt: NOW},
+    ])
+  })
+
+  it('supports both quote token variants', () => {
+    let prev: PostTypeFiltersRecord = emptyRecord()
+    prev = {
+      ...prev,
+      filters: addFilter(prev.filters, SUBJECT_A, QUOTE, NOW),
+    }
+    prev = {
+      ...prev,
+      filters: addFilter(prev.filters, SUBJECT_A, QUOTE_MEDIA, NOW),
+    }
+    const result = buildRecord(prev, {op: 'remove', subject: SUBJECT_A, type: QUOTE}, NOW)
+    expect(result.action).toBe('put')
+    expect(result.record.filters[0].types).toEqual([QUOTE_MEDIA])
+  })
+})

--- a/src/state/queries/post-type-filters/serde.ts
+++ b/src/state/queries/post-type-filters/serde.ts
@@ -1,0 +1,126 @@
+import {KNOWN_TYPES} from './client-map'
+import {
+  POST_TYPE_FILTER_NSID,
+  type AuthorFilter,
+  type PostTypeFiltersRecord,
+} from './types'
+
+export type FilterOp =
+  | {op: 'add'; subject: string; type: string}
+  | {op: 'remove'; subject: string; type: string}
+
+function isKnownType(t: string): t is (typeof KNOWN_TYPES)[number] {
+  return (KNOWN_TYPES as readonly string[]).includes(t)
+}
+
+function findIndex(
+  filters: readonly AuthorFilter[],
+  subject: string,
+): number {
+  return filters.findIndex(f => f.subject === subject)
+}
+
+function dedupeTypes(types: readonly string[]): string[] {
+  const seen = new Set<string>()
+  const out: string[] = []
+  for (const t of types) {
+    if (!seen.has(t)) {
+      seen.add(t)
+      out.push(t)
+    }
+  }
+  return out
+}
+
+export function addFilter(
+  prev: readonly AuthorFilter[] | null | undefined,
+  subject: string,
+  type: string,
+  now: string,
+): AuthorFilter[] {
+  if (!isKnownType(type)) return prev ? [...prev] : []
+  const i = findIndex(prev ?? [], subject)
+  if (i === -1) {
+    const base = prev ? [...prev] : []
+    base.push({subject, types: [type], createdAt: now, updatedAt: now})
+    return base
+  }
+  const existing = (prev as AuthorFilter[])[i]
+  if (existing.types.includes(type)) return prev as AuthorFilter[]
+  const base = [...(prev as AuthorFilter[])]
+  base[i] = {
+    ...existing,
+    types: dedupeTypes([...existing.types, type]),
+    updatedAt: now,
+  }
+  return base
+}
+
+export function removeFilter(
+  prev: readonly AuthorFilter[] | null | undefined,
+  subject: string,
+  type: string,
+): AuthorFilter[] {
+  if (!prev) return []
+  const i = findIndex(prev, subject)
+  if (i === -1) return prev as AuthorFilter[]
+  const existing = prev[i]
+  const nextTypes = existing.types.filter(t => t !== type)
+  if (nextTypes.length === existing.types.length) {
+    return prev as AuthorFilter[]
+  }
+  const base = [...prev]
+  if (nextTypes.length === 0) {
+    base.splice(i, 1)
+    return base
+  }
+  base[i] = {...existing, types: nextTypes}
+  return base
+}
+
+export function applyOp(
+  prev: readonly AuthorFilter[] | null | undefined,
+  op: FilterOp,
+  now: string,
+): AuthorFilter[] {
+  if (op.op === 'add') {
+    return addFilter(prev, op.subject, op.type, now)
+  }
+  return removeFilter(prev, op.subject, op.type)
+}
+
+/**
+ * Builds the next record from the cached one and an op.
+ *
+ * Returns `null` when the mutation should be a network no-op:
+ *  - `prev` is `null` (no record exists) and the next filter list is empty.
+ *
+ * Callers must dispatch on the return: non-null → `putRecord`, null when
+ * `prev` was non-null → `deleteRecord`, null when `prev` was `null` → no-op.
+ */
+export function buildRecord(
+  prev: PostTypeFiltersRecord | null | undefined,
+  op: FilterOp,
+  now: string = new Date().toISOString(),
+): {action: 'put' | 'delete' | 'noop'; record: PostTypeFiltersRecord} {
+  const nextFilters = applyOp(prev?.filters, op, now)
+  if (nextFilters.length === 0) {
+    if (!prev) return {action: 'noop', record: emptyRecord()}
+    return {
+      action: 'delete',
+      record: emptyRecord(),
+    }
+  }
+  return {
+    action: 'put',
+    record: {
+      $type: POST_TYPE_FILTER_NSID,
+      filters: nextFilters,
+      updatedAt: now,
+    },
+  }
+}
+
+function emptyRecord(): PostTypeFiltersRecord {
+  return {$type: POST_TYPE_FILTER_NSID, filters: []}
+}

--- a/src/state/queries/post-type-filters/types.ts
+++ b/src/state/queries/post-type-filters/types.ts
@@ -1,0 +1,25 @@
+// Schema: see ./preference-feed.json (community.lexicon.preference.feed)
+//
+// Hand-mirrored from the JSON so the runtime has no JSON-walk dependency.
+// The `knownValues` array in the JSON is also derived into `KNOWN_TYPES` via
+// client-map.ts (single source of truth for the `$type` token universe).
+
+import {parseLexiconDoc, type LexiconDoc} from '@atproto/lexicon'
+
+import lex from './preference-feed.json'
+
+export const POST_TYPE_FILTER_LEXICON: LexiconDoc = parseLexiconDoc(lex)
+export const POST_TYPE_FILTER_NSID = POST_TYPE_FILTER_LEXICON.id
+
+export type AuthorFilter = {
+  subject: string
+  types: string[]
+  createdAt?: string
+  updatedAt?: string
+}
+
+export type PostTypeFiltersRecord = {
+  $type: typeof POST_TYPE_FILTER_NSID
+  filters: AuthorFilter[]
+  updatedAt?: string
+}

--- a/src/view/com/posts/PostFeedItem.tsx
+++ b/src/view/com/posts/PostFeedItem.tsx
@@ -295,6 +295,9 @@ let FeedItemInner = ({
       return {
         uri: reason.uri,
         cid: reason.cid,
+        by: reason.by
+          ? {did: reason.by.did, handle: reason.by.handle}
+          : undefined,
       }
     }
   }, [reason])

--- a/src/view/com/profile/ProfileMenu.tsx
+++ b/src/view/com/profile/ProfileMenu.tsx
@@ -16,6 +16,16 @@ import {
   useProfileFollowMutationQueue,
   useProfileMuteMutationQueue,
 } from '#/state/queries/profile'
+import {
+  usePostTypeFiltersQuery,
+  useUpdatePostTypeFiltersMutation,
+} from '#/state/queries/post-type-filters'
+import {
+  QUOTE_TYPES,
+  REPOST_TYPE,
+  isQuoteFilter,
+  isRepostFilter,
+} from '#/state/queries/post-type-filters/client-map'
 import {useSession} from '#/state/session'
 import {EventStopper} from '#/view/com/util/EventStopper'
 import {atoms as a, useTheme} from '#/alf'
@@ -34,6 +44,9 @@ import {ListSparkle_Stroke2_Corner0_Rounded as List} from '#/components/icons/Li
 import {Live_Stroke2_Corner0_Rounded as LiveIcon} from '#/components/icons/Live'
 import {MagnifyingGlass_Stroke2_Corner0_Rounded as SearchIcon} from '#/components/icons/MagnifyingGlass'
 import {Mute_Stroke2_Corner0_Rounded as Mute} from '#/components/icons/Mute'
+import {Eye_Stroke2_Corner0_Rounded as Eye} from '#/components/icons/Eye'
+import {EyeSlash_Stroke2_Corner0_Rounded as EyeSlash} from '#/components/icons/EyeSlash'
+import {Filter_Stroke2_Corner0_Rounded as Filter} from '#/components/icons/Filter'
 import {PeopleRemove2_Stroke2_Corner0_Rounded as UserMinus} from '#/components/icons/PeopleRemove2'
 import {
   PersonCheck_Stroke2_Corner0_Rounded as PersonCheck,
@@ -98,6 +111,33 @@ let ProfileMenu = ({
     profile,
     'ProfileMenu',
   )
+
+  const {data: filterRecord} = usePostTypeFiltersQuery()
+  const {mutate: updateFilters} = useUpdatePostTypeFiltersMutation()
+
+  const filterForThisProfile = !isSelf
+    ? filterRecord?.filters?.find(f => f.subject === profile.did)
+    : undefined
+  const isRepostFilterOn = isRepostFilter(filterForThisProfile?.types ?? [])
+  const isQuoteFilterOn = isQuoteFilter(filterForThisProfile?.types ?? [])
+
+  const onToggleRepostFilter = () => {
+    if (isSelf) return
+    updateFilters({
+      op: isRepostFilterOn ? 'remove' : 'add',
+      subject: profile.did,
+      type: REPOST_TYPE,
+    })
+  }
+
+  const onToggleQuoteFilter = () => {
+    if (isSelf) return
+    updateFilters({
+      op: isQuoteFilterOn ? 'remove' : 'add',
+      subject: profile.did,
+      type: QUOTE_TYPES[0],
+    })
+  }
 
   const blockPromptControl = Prompt.usePromptControl()
   const loggedOutWarningPromptControl = Prompt.usePromptControl()
@@ -477,6 +517,50 @@ let ProfileMenu = ({
                           }
                         />
                       </Menu.Item>
+                    )}
+                    {!isSelf && (
+                      <>
+                        <Menu.Item
+                          testID="profileHeaderDropdownHideRepostsBtn"
+                          label={
+                            isRepostFilterOn
+                              ? l`Show reposts from this account`
+                              : l`Hide reposts from this account`
+                          }
+                          onPress={onToggleRepostFilter}>
+                          <Menu.ItemText>
+                            {isRepostFilterOn ? (
+                              <Trans>Show reposts from this account</Trans>
+                            ) : (
+                              <Trans>Hide reposts from this account</Trans>
+                            )}
+                          </Menu.ItemText>
+                          <Menu.ItemIcon
+                            icon={isRepostFilterOn ? Eye : EyeSlash}
+                          />
+                        </Menu.Item>
+                        <Menu.Item
+                          testID="profileHeaderDropdownHideQuotePostsBtn"
+                          label={
+                            isQuoteFilterOn
+                              ? l`Show quote posts from this account`
+                              : l`Hide quote posts from this account`
+                          }
+                          onPress={onToggleQuoteFilter}>
+                          <Menu.ItemText>
+                            {isQuoteFilterOn ? (
+                              <Trans>
+                                Show quote posts from this account
+                              </Trans>
+                            ) : (
+                              <Trans>Hide quote posts from this account</Trans>
+                            )}
+                          </Menu.ItemText>
+                          <Menu.ItemIcon
+                            icon={isQuoteFilterOn ? Eye : EyeSlash}
+                          />
+                        </Menu.Item>
+                      </>
                     )}
                     <Menu.Item
                       testID="profileHeaderDropdownReportBtn"

--- a/src/view/screens/ModerationFilteredAccounts.tsx
+++ b/src/view/screens/ModerationFilteredAccounts.tsx
@@ -1,0 +1,302 @@
+import {useCallback, useMemo} from 'react'
+import {ActivityIndicator, View} from 'react-native'
+import {type AppBskyActorDefs} from '@atproto/api'
+import {Trans, useLingui} from '@lingui/react/macro'
+import {useNavigation} from '@react-navigation/native'
+import {useQueryClient} from '@tanstack/react-query'
+
+import {cleanError} from '#/lib/strings/errors'
+import {logger} from '#/logger'
+import {
+  type UpdateOp,
+  usePostTypeFiltersQuery,
+  useUpdatePostTypeFiltersMutation,
+} from '#/state/queries/post-type-filters'
+import {
+  QUOTE_TYPES,
+  REPOST_TYPE,
+  isQuoteFilter,
+  isRepostFilter,
+} from '#/state/queries/post-type-filters/client-map'
+import {useProfileQuery} from '#/state/queries/profile'
+import {type NavigationProp} from '#/lib/routes/types'
+import {atoms as a, useTheme} from '#/alf'
+import {Button, ButtonIcon, ButtonText} from '#/components/Button'
+import * as Admonition from '#/components/Admonition'
+import {Filter_Stroke2_Corner0_Rounded as FilterIcon} from '#/components/icons/Filter'
+import {Link} from '#/components/Link'
+import {makeProfileLink} from '#/lib/routes/links'
+import * as Layout from '#/components/Layout'
+import {Text} from '#/components/Typography'
+import {Eye_Stroke2_Corner0_Rounded as Eye} from '#/components/icons/Eye'
+
+type Props = {
+  navigation: NavigationProp
+}
+
+function describeTypes(
+  types: readonly string[],
+  isRepostOn: boolean,
+  isQuoteOn: boolean,
+): string {
+  const labels: string[] = []
+  if (isRepostOn) labels.push('Reposts')
+  if (isQuoteOn) labels.push('Quote posts')
+  return labels.join(', ')
+}
+
+function FilterRow({
+  did,
+  types,
+  onToggleRepost,
+  onToggleQuote,
+  onRemoveAll,
+}: {
+  did: string
+  types: readonly string[]
+  onToggleRepost: () => void
+  onToggleQuote: () => void
+  onRemoveAll: () => void
+}) {
+  const t = useTheme()
+  const {data: profile, isLoading} = useProfileQuery({did})
+  const isRepostOn = isRepostFilter(types)
+  const isQuoteOn = isQuoteFilter(types)
+  const allActive = isRepostOn && isQuoteOn
+
+  return (
+    <View
+      style={[a.py_lg, a.px_xl, a.border_t, t.atoms.border_contrast_low]}
+      testID={`filteredAccount-${did}`}>
+      <View style={[a.flex_row, a.align_center, a.gap_md, a.pb_md]}>
+        <View style={[a.flex_1]}>
+          {isLoading ? (
+            <ActivityIndicator />
+          ) : profile ? (
+            <Link
+              label={
+                profile.displayName ?? profile.handle ?? did
+              }
+              to={makeProfileLink(profile)}>
+              <Text
+                style={[a.text_md, a.font_semi_bold, t.atoms.text_contrast_high]}>
+                {profile.displayName ?? profile.handle ?? did}
+              </Text>
+              {profile.handle && profile.handle !== profile.displayName ? (
+                <Text
+                  style={[
+                    a.text_sm,
+                    t.atoms.text_contrast_medium,
+                  ]}>
+                  @{profile.handle}
+                </Text>
+              ) : null}
+            </Link>
+          ) : (
+            <Text style={[a.text_md, a.font_semi_bold]} numberOfLines={1}>
+              {did}
+            </Text>
+          )}
+          <Text
+            style={[a.text_sm, a.mt_xs, t.atoms.text_contrast_medium]}>
+            <Trans>Filtering: {describeTypes(types, isRepostOn, isQuoteOn)}</Trans>
+          </Text>
+        </View>
+      </View>
+      <View style={[a.flex_row, a.gap_sm, a.flex_wrap]}>
+        {isRepostOn && (
+          <Button
+            variant="outline"
+            color="secondary"
+            label="Show reposts"
+            onPress={onToggleRepost}
+            testID={`filteredAccount-repost-${did}`}>
+            <ButtonText>Show reposts</ButtonText>
+            <ButtonIcon icon={Eye} />
+          </Button>
+        )}
+        {isQuoteOn && (
+          <Button
+            variant="outline"
+            color="secondary"
+            label="Show quote posts"
+            onPress={onToggleQuote}
+            testID={`filteredAccount-quote-${did}`}>
+            <ButtonText>Show quote posts</ButtonText>
+            <ButtonIcon icon={Eye} />
+          </Button>
+        )}
+        {allActive && (
+          <Button
+            variant="outline"
+            color="negative"
+            label="Remove all filters"
+            onPress={onRemoveAll}
+            testID={`filteredAccount-removeAll-${did}`}>
+            <ButtonText>Remove all filters</ButtonText>
+          </Button>
+        )}
+      </View>
+    </View>
+  )
+}
+
+export function ModerationFilteredAccounts(_props: Props) {
+  const t = useTheme()
+  const {data, isLoading, error, refetch} = usePostTypeFiltersQuery()
+  const updateFilters = useUpdatePostTypeFiltersMutation()
+  const navigation = useNavigation<NavigationProp>()
+  const queryClient = useQueryClient()
+  const filters = data?.filters ?? []
+
+  const grouped = useMemo(() => {
+    return filters.map(f => ({
+      did: f.subject,
+      types: f.types,
+    }))
+  }, [filters])
+
+  const refresh = useCallback(async () => {
+    try {
+      await refetch()
+    } catch (err) {
+      logger.error('Failed to refresh filtered accounts', {message: err})
+    }
+  }, [refetch])
+
+  const removeType = useCallback(
+    (subject: string, type: string) => {
+      const op: UpdateOp = {op: 'remove', subject, type}
+      updateFilters.mutate(op)
+    },
+    [updateFilters],
+  )
+
+  const removeAllFor = useCallback(
+    (subject: string) => {
+      removeType(subject, REPOST_TYPE)
+      setTimeout(() => removeType(subject, QUOTE_TYPES[0]), 50)
+    },
+    [removeType],
+  )
+
+  const isEmpty = !isLoading && filters.length === 0
+
+  return (
+    <Layout.Screen testID="filteredAccountsScreen">
+      <Layout.Header.Outer>
+        <Layout.Header.BackButton />
+        <Layout.Header.Content>
+          <Layout.Header.TitleText>
+            <Trans>Filtered Accounts</Trans>
+          </Layout.Header.TitleText>
+        </Layout.Header.Content>
+        <Layout.Header.Slot />
+      </Layout.Header.Outer>
+      <Layout.Content>
+        {isLoading ? (
+          <View style={[a.p_xl, a.gap_md]}>
+            <Admonition.Outer type="info" style={[a.flex_1]}>
+              <Admonition.Row>
+                <Admonition.Icon />
+                <Admonition.Content>
+                  <Admonition.Text>
+                    <Trans>Filters haven't loaded yet.</Trans>
+                  </Admonition.Text>
+                </Admonition.Content>
+              </Admonition.Row>
+            </Admonition.Outer>
+          </View>
+        ) : error && filters.length === 0 ? (
+          <View style={[a.p_xl, a.gap_md]}>
+            <Text
+              style={[
+                a.text_md,
+                a.leading_normal,
+                a.pb_md,
+                t.atoms.text_contrast_medium,
+              ]}>
+              <Trans>
+                We were unable to load your post-type filters at this time.
+              </Trans>
+            </Text>
+            <Text style={[a.text_md, a.leading_normal]}>
+              {cleanError(error)}
+            </Text>
+            <Button
+              variant="solid"
+              color="primary"
+              onPress={refresh}
+              label="Try again">
+              <ButtonText>Try again</ButtonText>
+            </Button>
+          </View>
+        ) : isEmpty ? (
+          <View
+            style={[a.pt_2xl, a.px_xl, a.align_center, a.gap_lg]}>
+            <FilterIcon
+              size="xl"
+              style={[t.atoms.text_contrast_medium]}
+            />
+            <View
+              style={[
+                a.py_md,
+                a.px_lg,
+                a.rounded_sm,
+                t.atoms.bg_contrast_25,
+                a.border,
+                t.atoms.border_contrast_low,
+                {maxWidth: 400},
+              ]}>
+              <Text
+                style={[a.text_sm, a.text_center, t.atoms.text_contrast_high]}>
+                <Trans>
+                  You haven't filtered any accounts yet. To filter an
+                  account, open the menu on one of their posts or on their
+                  profile.
+                </Trans>
+              </Text>
+            </View>
+          </View>
+        ) : (
+          <View style={[]}>
+            <Info />
+            {grouped.map(f => (
+              <FilterRow
+                key={f.did}
+                did={f.did}
+                types={f.types}
+                onToggleRepost={() => removeType(f.did, REPOST_TYPE)}
+                onToggleQuote={() => removeType(f.did, QUOTE_TYPES[0])}
+                onRemoveAll={() => removeAllFor(f.did)}
+              />
+            ))}
+          </View>
+        )}
+      </Layout.Content>
+    </Layout.Screen>
+  )
+}
+
+function Info() {
+  const t = useTheme()
+  return (
+    <View
+      style={[
+        a.w_full,
+        t.atoms.bg_contrast_25,
+        a.py_md,
+        a.px_xl,
+        a.border_t,
+        {marginTop: a.border.borderWidth * -1},
+        t.atoms.border_contrast_low,
+      ]}>
+      <Text style={[a.text_center, a.text_sm, t.atoms.text_contrast_high]}>
+        <Trans>
+          Filtered accounts have their selected post types hidden from your
+          feed. Filters are stored on your PDS and sync across devices.
+        </Trans>
+      </Text>
+    </View>
+  )
+}


### PR DESCRIPTION
Let users filter reposts and quote posts from specific accounts out of all feeds. Independent from existing ATProto mutes. Filters are stored as a PDS record under community.lexicon.preference.feed at rkey 'self', so they sync across devices for the same account. Applies to every feed descriptor.

This is more-or-less an implementation of the Idea demonstrated in https://discourse.atprotocol.community/t/proposal-community-lexicon-preference-feed-per-author-post-type-filters/954/7 and I imagine this would be a good quality of life feature for folks who want to follow people but want to reduce noise from high volume posters. It being done client side is a bit of a downside and frankly could be done in a feed but this approach makes it more accessible (since folks can't edit feeds).