### PR TITLE
Fix video URL in community-only post fallback embeds

### DIFF
--- a/src/state/queries/microcosm-fallback.ts
+++ b/src/state/queries/microcosm-fallback.ts
@@ -2,7 +2,7 @@
 import {AtUri, type ComAtprotoLabelDefs} from '@atproto/api'
 import {type QueryClient} from '@tanstack/react-query'
 
-import {PUBLIC_APPVIEW} from '#/lib/constants'
+import {PUBLIC_APPVIEW, VIDEO_SERVICE} from '#/lib/constants'
 import {isDidBlocked} from './my-blocked-accounts'
 import {isDidMuted} from './my-muted-accounts'
 
@@ -419,11 +419,15 @@ function resolveSingleEmbed(authorDid: string, embed: any): any | null {
       const cid = embed.video?.ref?.$link
       if (!cid) return null
 
+      // Match the URL the AppView emits for the same embed: Blacksky's
+      // video service (rsky-video) serves at `/stream/`, not `video.bsky.app/watch/`.
+      // The DID is URL-encoded to mirror the AppView's `#view` output.
+      const encodedDid = encodeURIComponent(authorDid)
       return {
         $type: 'app.bsky.embed.video#view',
         cid,
-        playlist: `https://video.bsky.app/watch/${authorDid}/${cid}/playlist.m3u8`,
-        thumbnail: `https://video.bsky.app/watch/${authorDid}/${cid}/thumbnail.jpg`,
+        playlist: `${VIDEO_SERVICE}/stream/${encodedDid}/${cid}/playlist.m3u8`,
+        thumbnail: `${VIDEO_SERVICE}/stream/${encodedDid}/${cid}/thumbnail.jpg`,
         alt: embed.alt || '',
         aspectRatio: embed.aspectRatio,
       }


### PR DESCRIPTION
## Problem
When the Blacksky client renders a **community-only post that quotes a video post**, the quoted video fails to load (blank player).

Community-only posts aren't indexed by the AppView, so the client synthesizes their embed views client-side in `microcosm-fallback.ts` (`resolveSingleEmbed`). The video case hardcoded **Bluesky's** CDN:

```
https://video.bsky.app/watch/<did>/<cid>/playlist.m3u8  → 404
```

Wrong two ways for Blacksky-hosted videos:
- **Wrong host** — `video.bsky.app` is Bluesky's service; Blacksky videos live on `video.blacksky.community` (rsky-video).
- **Wrong path** — rsky-video serves at `/stream/`, not `/watch/`.

The **direct** view of the same post works because it goes through the AppView, which emits the correct `video.blacksky.community/stream/...` URL. Only the community-only fallback path (which bypasses the AppView) built the URL wrong.

## Fix
Build video playlist/thumbnail URLs from the `VIDEO_SERVICE` constant + `/stream/` path — matching the URL the AppView produces for the same embed. DID is URL-encoded to mirror the AppView's `#view` output.

## Verification
- Reproduced from a HAR of a community-only quote: fallback requested `video.bsky.app/watch/...` → 404.
- Corrected URL `video.blacksky.community/stream/<did>/<cid>/playlist.m3u8` → 307 → Bunny CDN (plays) for the same video.
- Also covers `recordWithMedia` (video-in-quote), which routes media through the same resolver.

## Scope / safety
- **Only** the `app.bsky.embed.video` branch changed. Images (`cdn.bsky.app`) and external embeds untouched — `cdn.bsky.app` already serves any DID, so images were never broken.
- Bug introduced by c916a66 ("Fix missing embeds in fallback posts and thread fallback"), which reused the upstream `video.bsky.app` pattern.