### PR TITLE
Emit at:canonical meta tags per the at-tags proposal

### DIFF
--- a/bskyweb/cmd/bskyweb/server.go
+++ b/bskyweb/cmd/bskyweb/server.go
@@ -844,6 +844,11 @@ func (srv *Server) WebPost(c echo.Context) error {
 	// handle is unusable (template strips query/fragment).
 	canonicalURL := bskyPostURL(pv.Handle, rkey.String())
 
+	// DID-form AT-URI of the post record, emitted as <meta name="at:canonical">
+	// per the at-tags proposal (https://tangled.org/chrisshank.com/at-tags).
+	atURI := fmt.Sprintf("at://%s/app.bsky.feed.post/%s", pv.Did, rkey)
+	data["atURI"] = atURI
+
 	if !unauthedViewingOkay {
 		// Provide minimal OpenGraph data for auth-required posts
 		data["requestURI"] = requestURI
@@ -861,7 +866,7 @@ func (srv *Server) WebPost(c echo.Context) error {
 	}
 
 	// then fetch the post thread (with extra context)
-	uri := fmt.Sprintf("at://%s/app.bsky.feed.post/%s", pv.Did, rkey)
+	uri := atURI
 	tpv, err := appbsky.FeedGetPostThread(ctx, srv.xrpcc, 1, 0, uri)
 	if err != nil {
 		log.Warnf("failed to fetch post: %s\t%v", uri, err)
@@ -944,6 +949,8 @@ func (srv *Server) WebStarterPack(c echo.Context) error {
 		return c.Render(http.StatusOK, "starterpack.html", data)
 	}
 	data["title"] = rec.Name
+	// DID-form AT-URI from the view (starterPackURI may be handle-form).
+	data["atURI"] = spv.StarterPack.Uri
 	if srv.cfg.ogcardHost != "" {
 		data["imgThumbUrl"] = fmt.Sprintf("%s/start/%s/%s", srv.cfg.ogcardHost, identifier, rkey)
 	}
@@ -1011,6 +1018,7 @@ func (srv *Server) WebProfile(c echo.Context) error {
 	data["profileView"] = pv
 	data["requestURI"] = fmt.Sprintf("https://%s%s", req.Host, req.URL.Path)
 	data["requestHost"] = req.Host
+	data["atURI"] = fmt.Sprintf("at://%s/app.bsky.actor.profile/self", pv.Did)
 
 	// Prefer the handle-form URL so JSON-LD `url` and
 	// <link rel="canonical"> match. Template falls back to requestURI
@@ -1102,6 +1110,7 @@ func (srv *Server) WebFeed(c echo.Context) error {
 	req := c.Request()
 	data["feedView"] = fgv.View
 	data["requestURI"] = fmt.Sprintf("https://%s%s", req.Host, req.URL.Path)
+	data["atURI"] = feedURI
 
 	return c.Render(http.StatusOK, "feed.html", data)
 }

--- a/bskyweb/templates/feed.html
+++ b/bskyweb/templates/feed.html
@@ -39,6 +39,9 @@
   <meta name="twitter:value1" content="@{{ feedView.Creator.Handle }}">
 
   <link rel="alternate" href="{{ feedView.Uri }}" />
+  {%- if atURI %}
+  <meta name="at:canonical" content="{{ atURI }}">
+  {% endif -%}
 {% endif -%}
 {%- endblock %}
 

--- a/bskyweb/templates/post.html
+++ b/bskyweb/templates/post.html
@@ -14,6 +14,9 @@
 {%- if postView -%}
   <meta property="og:type" content="article">
   <meta property="profile:username" content="{{ postView.Author.Handle }}">
+  {%- if atURI %}
+  <meta name="at:canonical" content="{{ atURI }}">
+  {% endif -%}
   {%- if requestURI %}
   {% if canonicalURL %}
   <meta property="og:url" content="{{ canonicalURL }}">
@@ -75,6 +78,9 @@
 {%- elif requiresAuth and profileHandle -%}
   <meta property="og:type" content="article">
   <meta property="profile:username" content="{{ profileHandle }}">
+  {%- if atURI %}
+  <meta name="at:canonical" content="{{ atURI }}">
+  {% endif -%}
   {%- if requestURI %}
   {% if canonicalURL %}
   <meta property="og:url" content="{{ canonicalURL }}">

--- a/bskyweb/templates/profile.html
+++ b/bskyweb/templates/profile.html
@@ -30,6 +30,9 @@
   {% endif -%}
 
   <link rel="alternate" href="at://{{ profileView.Did }}/app.bsky.actor.profile/self" />
+  {%- if atURI %}
+  <meta name="at:canonical" content="{{ atURI }}">
+  {% endif -%}
 
   <meta name="twitter:label1" content="Account DID">
   <meta name="twitter:value1" content="{{ profileView.Did }}">

--- a/bskyweb/templates/starterpack.html
+++ b/bskyweb/templates/starterpack.html
@@ -5,6 +5,9 @@
   {%- if requestURI %}
   <meta property="og:url" content="{{ requestURI }}">
   {% endif -%}
+  {%- if atURI %}
+  <meta name="at:canonical" content="{{ atURI }}">
+  {% endif -%}
   {%- if imgThumbUrl %}
   <meta property="og:image" content="{{ imgThumbUrl }}">
   <meta property="twitter:image" content="{{ imgThumbUrl }}">


### PR DESCRIPTION
Adds <meta name="at:canonical"> with the DID-form AT-URI of the record each page renders (post, profile, feed generator, starter pack), per https://tangled.org/chrisshank.com/at-tags. Lets clients, embedders, and crawlers map our web pages back to their canonical atproto records without scraping URL structures.