### PR TITLE
fix(ios): pin MMKV to 2.4.0 to unblock Xcode 26 builds

### DIFF
--- a/app.config.js
+++ b/app.config.js
@@ -287,6 +287,10 @@ module.exports = function (_config) {
                   git: 'https://github.com/bluesky-social/MCEmojiPicker.git',
                   branch: 'main',
                 },
+                // MMKV 2.4.1's secureClearMemory path calls memset_s, which fails to
+                // compile under Xcode 26. react-native-mmkv depends on MMKV ">= 1.3.3"
+                // with no upper bound, so pin below 2.4.1 until upstream fixes it.
+                {name: 'MMKV', version: '2.4.0'},
               ],
             },
             android: {


### PR DESCRIPTION
## Problem

The **Build and Submit iOS** workflow fails at archive time:

```
ios/Pods/MMKVCore/Core/aes/AESCrypt.cpp:83:11: use of undeclared identifier 'memset_s'
** ARCHIVE FAILED ** (exit 65)
```

No app code changed — this broke purely from a transitive dependency resolving to a new version.

## Root cause

- `ios/` is generated by `expo prebuild` each build, so there is **no committed `Podfile.lock`** — CocoaPods resolves fresh every run.
- `react-native-mmkv` (the `@bsky.app/react-native-mmkv@2.12.5` fork) declares `s.dependency "MMKV", ">= 1.3.3"` — **open-ended, no upper bound**.
- **MMKV `v2.4.1`** (latest) introduced a `secureClearMemory` path that calls `memset_s`. `v2.4.0` and earlier don't have it.
- Our iOS job builds `--local` on `macos-26-xlarge` with **Xcode 26.4 pinned** (`build-submit-ios.yml`), and Xcode 26 rejects that `memset_s` path → archive fails.

Upstream bluesky-social/social-app has the same unpinned MMKV but builds on **EAS cloud** (older Xcode), so they haven't hit it yet — they will once EAS moves to Xcode 26.

## Fix

Pin MMKV below `2.4.1` via the existing `extraPods` block, which writes `pod 'MMKV', '2.4.0'` into the generated Podfile and overrides the open range.

## Testing

- `node --check app.config.js` passes; lint-staged (eslint + prettier) clean on commit.
- Full validation is the iOS workflow re-run — pod resolution + archive under Xcode 26.4.

## Notes

- No `package.json` version bump: that's the App Store marketing version, bumped per release, not per build-config fix.
- Candidate to send upstream — same one-line pin applies.