### PR TITLE
fix(ci): set EAS_NO_VCS on PR OTA publish so intl:build dirty tree doesn't fail eoas

### DIFF
--- a/.github/workflows/pull-request-comment.yml
+++ b/.github/workflows/pull-request-comment.yml
@@ -186,6 +186,9 @@ jobs:
           --nonInteractive
           --message="PR #${{ github.event.issue.number }}"
         env:
+          # intl:build dirties tracked .po files; skip eoas's git-clean check
+          # (matches bundle-deploy-eas-update.yml)
+          EAS_NO_VCS: '1'
           EXPO_TOKEN: ${{ secrets.EXPO_TOKEN }}
           SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
           SENTRY_RELEASE: ${{ steps.env.outputs.EXPO_PUBLIC_RELEASE_VERSION }}


### PR DESCRIPTION
## Problem
The PR-comment OTA path (`@github-actions ota`) fails at the `eoas publish` step with:

> Your repository working tree is dirty. This operation needs to be run on a clean working tree.

The earlier **🔤 Compile translations** step (`pnpm intl:build`) regenerates tracked `src/locale/locales/*/messages.po` files, leaving a dirty tree. `eoas publish` then aborts on its git-clean check. This breaks the per-PR OTA for every PR (observed on #151, run 30835209851).

## Fix
Add `EAS_NO_VCS: '1'` to the publish step's env, matching the already-working main `bundle-deploy-eas-update.yml`, which sets it for the same reason.

## Scope
One line + comment in `.github/workflows/pull-request-comment.yml`. No behavior change beyond skipping the VCS clean check (the bundle content is unaffected).