### PR TITLE
fix(ci): create and point pull-request-<n> OTA channel on publish

### DIFF
--- a/.github/workflows/pull-request-comment.yml
+++ b/.github/workflows/pull-request-comment.yml
@@ -191,6 +191,21 @@ jobs:
           SENTRY_RELEASE: ${{ steps.env.outputs.EXPO_PUBLIC_RELEASE_VERSION }}
           SENTRY_DIST: ${{ steps.env.outputs.EXPO_PUBLIC_BUNDLE_IDENTIFIER }}
 
+      - name: 🔗 Point PR channel at its branch
+        env:
+          EXPO_TOKEN: ${{ secrets.EXPO_TOKEN }}
+          PR_CHANNEL: pull-request-${{ github.event.issue.number }}
+        # eoas publish creates only the branch. The client retargets OTA at a
+        # channel named pull-request-<n> at runtime, so that channel must exist
+        # and point at the matching branch — otherwise the manifest request
+        # returns an empty branch mapping and 500s. Create-if-absent, then
+        # always (re)point so re-runs and force-pushes stay correct.
+        run: |
+          if ! eas channel:view "$PR_CHANNEL" >/dev/null 2>&1; then
+            eas channel:create "$PR_CHANNEL" --non-interactive
+          fi
+          eas channel:edit "$PR_CHANNEL" --branch "$PR_CHANNEL" --non-interactive
+
       - name: 💬 Drop a comment
         uses: marocchino/sticky-pull-request-comment@0ea0beb66eb9baf113663a64ec522f60e49231c0 # v3.0.4
         env:


### PR DESCRIPTION
The PR OTA publish step runs `eoas publish --branch=pull-request-<n>`, which creates only the **branch**. The client, however, retargets updates at runtime to a **channel** named `pull-request-<n>` (via `Updates.setUpdateURLAndRequestHeadersOverride` in `useOTAUpdates.ts`). With no matching channel, `expo-open-ota` resolves an empty branch mapping and the manifest request 500s on device (`error fetching channel mapping: unexpected end of JSON input`). The follow-up comment even claimed it published "to channel `pull-request-<n>`" when no channel existed.

## Fix
After `eoas publish`, create the `pull-request-<n>` channel if absent, then always point it at the matching branch. Idempotent, so PR re-runs and force-pushes stay correct.

## Notes
- No app-version bump: `version` doubles as `runtimeVersion` (appVersion policy), so bumping would shift the runtime and break OTA matching. CI-only change.
- Verified end-to-end by hand on PR #151: after manually creating+pointing the channel, the device applied the PR OTA successfully.