### PR TITLE
fix(ios): pin MMKVCore to 2.4.0 to unblock Xcode 26 builds

### DIFF
--- a/app.config.js
+++ b/app.config.js
@@ -287,10 +287,14 @@ module.exports = function (_config) {
                   git: 'https://github.com/bluesky-social/MCEmojiPicker.git',
                   branch: 'main',
                 },
-                // MMKV 2.4.1's secureClearMemory path calls memset_s, which fails to
-                // compile under Xcode 26. react-native-mmkv depends on MMKV ">= 1.3.3"
-                // with no upper bound, so pin below 2.4.1 until upstream fixes it.
+                // MMKVCore 2.4.1's AESCrypt.cpp calls memset_s on the MMKV_APPLE
+                // path, which fails to compile under Xcode 26 (memset_s is only
+                // declared when __STDC_WANT_LIB_EXT1__ == 1). Pinning MMKV alone is
+                // not enough: MMKV depends on MMKVCore with an open-ended range, so
+                // MMKVCore still floats to 2.4.1. Pin MMKVCore itself to 2.4.0 (which
+                // does not use memset_s) until upstream fixes it.
                 {name: 'MMKV', version: '2.4.0'},
+                {name: 'MMKVCore', version: '2.4.0'},
               ],
             },
             android: {


### PR DESCRIPTION
## Summary

The "Build and Submit iOS" workflow fails while compiling a native pod:

```
❌ (ios/Pods/MMKVCore/Core/aes/AESCrypt.cpp:83:11)
   81 | #elif defined(__STDC_LIB_EXT1__) || defined(MMKV_APPLE)
 > 83 |     (void)memset_s(ptr, len, 0, len);
      |           ^ use of undeclared identifier 'memset_s'
```

Under Xcode 26, `memset_s` is only declared when `__STDC_WANT_LIB_EXT1__ == 1`, so MMKVCore's unconditional call on the `MMKV_APPLE` path fails to compile.

The previous fix (#150) pinned `MMKV` to `2.4.0`, and that pin **did** take effect — but it wasn't enough. `MMKV`'s podspec depends on `MMKVCore` with an open-ended range, so `pod install` still floated `MMKVCore` to `2.4.1`, the version that introduced the `memset_s` call. The failed run's install log confirms it:

```
[INSTALL_PODS] Installing MMKV (2.4.0)
[INSTALL_PODS] Installing MMKVCore (2.4.1)   ← still 2.4.1
```

## Change

Pin `MMKVCore` directly to `2.4.0` in `app.config.js` `extraPods`, alongside the existing `MMKV` pin.

## Verification

Confirmed against upstream MMKV source:

- `MMKVCore` **2.4.0** `AESCrypt.cpp` — does **not** call `memset_s` ✅
- `MMKVCore` **2.4.1** `AESCrypt.cpp` — calls `memset_s` on the `MMKV_APPLE` path ❌

A fresh iOS build (which re-runs `pod install`) is needed to confirm `MMKVCore 2.4.0` is now resolved.

---
_Generated by [Claude Code](https://claude.ai/code/session_01As32P5FAkrgjbQtATem8Fu)_