### PR TITLE
fix(ci): bake metrics + GrowthBook env into PR OTA bundles

### DIFF
--- a/.github/workflows/pull-request-comment.yml
+++ b/.github/workflows/pull-request-comment.yml
@@ -176,6 +176,9 @@ jobs:
           echo "EXPO_PUBLIC_SENTRY_DSN=${{ secrets.SENTRY_DSN }}" >> .env
           echo "EXPO_PUBLIC_BITDRIFT_API_KEY=${{ secrets.BITDRIFT_API_KEY }}" >> .env
           echo "EXPO_PUBLIC_GCP_PROJECT_ID=${{ secrets.EXPO_PUBLIC_GCP_PROJECT_ID }}" >> .env
+          echo "EXPO_PUBLIC_METRICS_API_HOST=${{ secrets.EXPO_PUBLIC_METRICS_API_HOST }}" >> .env
+          echo "EXPO_PUBLIC_GROWTHBOOK_API_HOST=${{ secrets.EXPO_PUBLIC_GROWTHBOOK_API_HOST }}" >> .env
+          echo "EXPO_PUBLIC_GROWTHBOOK_CLIENT_KEY=${{ secrets.EXPO_PUBLIC_GROWTHBOOK_CLIENT_KEY }}" >> .env
           echo "$json" > google-services.json
 
       - name: 🚀 Publish PR OTA Update (eoas)


### PR DESCRIPTION
PR-channel OTA publishes (`pull-request-comment.yml`) were missing `EXPO_PUBLIC_METRICS_API_HOST`, `EXPO_PUBLIC_GROWTHBOOK_API_HOST`, and `EXPO_PUBLIC_GROWTHBOOK_CLIENT_KEY` in the Env step — the same three lines `bundle-deploy-eas-update.yml` already writes.

Since `EXPO_PUBLIC_*` values are inlined into the JS bundle at publish time, every PR-channel OTA bundle fell back to the upstream defaults in `src/env/common.ts` (`events.bsky.app` + upstream GrowthBook client key), so those bundles never received our feature flags. Found while testing #156, whose flag-gated behavior silently disappeared after applying a PR OTA.