### PR TITLE
fix(auth): complete Android OAuth sign-in when the redirect cold-starts the app

### DIFF
--- a/__tests__/state/oauth-client-native-signin.test.ts
+++ b/__tests__/state/oauth-client-native-signin.test.ts
@@ -44,6 +44,11 @@ beforeEach(() => {
 
 const REDIRECT = 'community.blacksky:/oauth/callback'
 
+// A real `state` is a fresh nonce per authorize(), and the redirect claim
+// registry is keyed on it to stay single-use, so each test needs its own.
+let stateSeq = 0
+const nextState = () => `st${++stateSeq}`
+
 test('completes via redirect deep-link, ignoring the browser dismiss', async () => {
   const client = makeClient()
   const promise = signInNativeAndroid(client, 'alice.test')
@@ -57,7 +62,7 @@ test('completes via redirect deep-link, ignoring the browser dismiss', async () 
   })
   expect(mockUrlHandler).toBeTruthy()
 
-  mockUrlHandler!({url: `${REDIRECT}?code=xyz&state=st`})
+  mockUrlHandler!({url: `${REDIRECT}?code=xyz&state=${nextState()}`})
 
   const session = await promise
   expect(session).toEqual({sub: 'did:plc:abc'})
@@ -75,7 +80,7 @@ test('ignores unrelated deep-links', async () => {
   mockUrlHandler!({url: 'community.blacksky:/intent/compose?text=hi'})
   expect(client.callback).not.toHaveBeenCalled()
 
-  mockUrlHandler!({url: `${REDIRECT}?code=ok&state=st`})
+  mockUrlHandler!({url: `${REDIRECT}?code=ok&state=${nextState()}`})
   await expect(promise).resolves.toEqual({sub: 'did:plc:abc'})
 })
 
@@ -100,7 +105,7 @@ test('surfaces an error redirect (Kind 2) via callback throwing', async () => {
   const promise = signInNativeAndroid(client, 'alice.test')
   await new Promise(r => setImmediate(r))
 
-  mockUrlHandler!({url: `${REDIRECT}?error=access_denied&state=st`})
+  mockUrlHandler!({url: `${REDIRECT}?error=access_denied&state=${nextState()}`})
   await expect(promise).rejects.toThrow('access_denied')
 })
 
@@ -109,7 +114,9 @@ test('completes via a double-slash redirect deep-link', async () => {
   const promise = signInNativeAndroid(client, 'alice.test')
   await new Promise(r => setImmediate(r))
 
-  mockUrlHandler!({url: 'community.blacksky://oauth/callback?code=ds&state=st'})
+  mockUrlHandler!({
+    url: `community.blacksky://oauth/callback?code=ds&state=${nextState()}`,
+  })
 
   const session = await promise
   expect(session).toEqual({sub: 'did:plc:abc'})

--- a/__tests__/state/oauth-redirect-recovery.test.ts
+++ b/__tests__/state/oauth-redirect-recovery.test.ts
@@ -67,15 +67,55 @@ describe('isOAuthCallbackUrl', () => {
 })
 
 describe('claimOAuthRedirect', () => {
-  test('only the first claimant of a URL may exchange it', () => {
+  test('only the first claimant of a redirect may exchange it', () => {
     const url = uniqueRedirect()
     expect(claimOAuthRedirect(url)).toBe(true)
     expect(claimOAuthRedirect(url)).toBe(false)
   })
 
-  test('claims are per-URL', () => {
+  test('distinct authorizations are claimed independently', () => {
     expect(claimOAuthRedirect(uniqueRedirect())).toBe(true)
     expect(claimOAuthRedirect(uniqueRedirect())).toBe(true)
+  })
+
+  // The two claimants read the URL from different native modules (RN's 'url'
+  // event vs Expo's getLinkingURL), so the strings can differ in shape for the
+  // same authorization. Keying on `state` is what makes the dedupe hold.
+  test('dedupes across slash forms of the same state', () => {
+    expect(
+      claimOAuthRedirect('community.blacksky:/oauth/callback?code=a&state=SS1'),
+    ).toBe(true)
+    expect(
+      claimOAuthRedirect(
+        'community.blacksky://oauth/callback?code=a&state=SS1',
+      ),
+    ).toBe(false)
+  })
+
+  test('dedupes when param order or extra params differ', () => {
+    expect(
+      claimOAuthRedirect('community.blacksky:/oauth/callback?code=b&state=SS2'),
+    ).toBe(true)
+    expect(
+      claimOAuthRedirect(
+        'community.blacksky:/oauth/callback?state=SS2&iss=https%3A%2F%2Fblacksky.app&code=b',
+      ),
+    ).toBe(false)
+  })
+
+  test('different states on the same path are not confused', () => {
+    expect(
+      claimOAuthRedirect('community.blacksky:/oauth/callback?code=c&state=SS3'),
+    ).toBe(true)
+    expect(
+      claimOAuthRedirect('community.blacksky:/oauth/callback?code=c&state=SS4'),
+    ).toBe(true)
+  })
+
+  test('a redirect with no state stays single-use', () => {
+    const url = 'community.blacksky:/oauth/callback?error=invalid_request'
+    expect(claimOAuthRedirect(url)).toBe(true)
+    expect(claimOAuthRedirect(url)).toBe(false)
   })
 })
 

--- a/__tests__/state/oauth-redirect-recovery.test.ts
+++ b/__tests__/state/oauth-redirect-recovery.test.ts
@@ -1,0 +1,152 @@
+/* eslint-disable @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-member-access -- test doubles model the untyped Expo OAuth client */
+import {
+  claimOAuthRedirect,
+  completeOAuthRedirect,
+  isOAuthCallbackUrl,
+  signInNativeAndroid,
+} from '#/state/session/oauth-client'
+
+// oauth-client.ts constructs `new ExpoOAuthClient(...)` at module load, which pulls
+// the expo native-module chain unavailable under jest.
+jest.mock('@atproto/oauth-client-expo', () => ({ExpoOAuthClient: class {}}))
+
+const mockOpenAuthSessionAsync = jest.fn().mockResolvedValue({type: 'dismiss'})
+jest.mock('expo-web-browser', () => ({
+  openAuthSessionAsync: (...a: any[]) => mockOpenAuthSessionAsync(...a),
+}))
+
+let mockUrlHandler: ((e: {url: string}) => void) | null = null
+jest.mock('expo-linking', () => ({
+  addEventListener: (_evt: string, cb: (e: {url: string}) => void) => {
+    mockUrlHandler = cb
+    return {remove: jest.fn()}
+  },
+}))
+
+function makeClient(overrides: Partial<any> = {}) {
+  return {
+    authorize: jest
+      .fn()
+      .mockResolvedValue(new URL('https://auth.example/authorize?x=1')),
+    callback: jest
+      .fn()
+      .mockResolvedValue({session: {sub: 'did:plc:abc'}, state: null}),
+    ...overrides,
+  } as any
+}
+
+beforeEach(() => {
+  mockUrlHandler = null
+  mockOpenAuthSessionAsync.mockClear()
+})
+
+// Each test needs a URL no earlier test has claimed — the claim registry is
+// module state, mirroring the real single-use-per-process behavior.
+let seq = 0
+const uniqueRedirect = () =>
+  `community.blacksky:/oauth/callback?code=c${seq++}&state=st${seq}`
+
+describe('isOAuthCallbackUrl', () => {
+  test('matches both single- and double-slash redirect forms', () => {
+    expect(
+      isOAuthCallbackUrl('community.blacksky:/oauth/callback?code=a'),
+    ).toBe(true)
+    expect(
+      isOAuthCallbackUrl('community.blacksky://oauth/callback?code=a'),
+    ).toBe(true)
+  })
+
+  test('rejects other deep-links', () => {
+    expect(
+      isOAuthCallbackUrl('community.blacksky:/intent/compose?text=hi'),
+    ).toBe(false)
+    expect(
+      isOAuthCallbackUrl('https://blacksky.community/oauth/callback'),
+    ).toBe(false)
+  })
+})
+
+describe('claimOAuthRedirect', () => {
+  test('only the first claimant of a URL may exchange it', () => {
+    const url = uniqueRedirect()
+    expect(claimOAuthRedirect(url)).toBe(true)
+    expect(claimOAuthRedirect(url)).toBe(false)
+  })
+
+  test('claims are per-URL', () => {
+    expect(claimOAuthRedirect(uniqueRedirect())).toBe(true)
+    expect(claimOAuthRedirect(uniqueRedirect())).toBe(true)
+  })
+})
+
+describe('completeOAuthRedirect', () => {
+  test('extracts params without new URL() and exchanges them', async () => {
+    const client = makeClient()
+    const session = await completeOAuthRedirect(
+      client,
+      'community.blacksky:/oauth/callback?code=xyz&state=st&iss=https%3A%2F%2Fblacksky.app',
+    )
+
+    expect(session).toEqual({sub: 'did:plc:abc'})
+    const params = client.callback.mock.calls[0][0] as URLSearchParams
+    expect(params.get('code')).toBe('xyz')
+    expect(params.get('iss')).toBe('https://blacksky.app')
+    expect(client.callback.mock.calls[0][1]).toEqual({
+      redirect_uri: 'community.blacksky:/oauth/callback',
+    })
+  })
+
+  test('works on the double-slash form the launcher may deliver', async () => {
+    const client = makeClient()
+    await completeOAuthRedirect(
+      client,
+      'community.blacksky://oauth/callback?code=ds&state=st',
+    )
+    const params = client.callback.mock.calls[0][0] as URLSearchParams
+    expect(params.get('code')).toBe('ds')
+  })
+
+  test('propagates an exhausted authorization window', async () => {
+    const client = makeClient({
+      callback: jest.fn().mockRejectedValue(new Error('Unknown state')),
+    })
+    await expect(
+      completeOAuthRedirect(client, uniqueRedirect()),
+    ).rejects.toThrow('Unknown state')
+  })
+})
+
+describe('signInNativeAndroid claim interaction', () => {
+  test('claims the redirect so cold-start recovery stands down', async () => {
+    const client = makeClient()
+    const url = uniqueRedirect()
+    const promise = signInNativeAndroid(client, 'alice.test')
+    await new Promise(r => setImmediate(r))
+
+    mockUrlHandler!({url})
+    await expect(promise).resolves.toEqual({sub: 'did:plc:abc'})
+
+    // The recovery path checks this before exchanging; a second exchange would
+    // fail against the now-spent state.
+    expect(claimOAuthRedirect(url)).toBe(false)
+    expect(client.callback).toHaveBeenCalledTimes(1)
+  })
+
+  test('a redirect already claimed elsewhere does not settle the sign-in', async () => {
+    const client = makeClient()
+    const url = uniqueRedirect()
+    expect(claimOAuthRedirect(url)).toBe(true) // e.g. recovery got there first
+
+    const promise = signInNativeAndroid(client, 'alice.test')
+    await new Promise(r => setImmediate(r))
+
+    mockUrlHandler!({url})
+    await new Promise(r => setImmediate(r))
+    expect(client.callback).not.toHaveBeenCalled()
+
+    // Still live, and a fresh redirect completes it.
+    const next = uniqueRedirect()
+    mockUrlHandler!({url: next})
+    await expect(promise).resolves.toEqual({sub: 'did:plc:abc'})
+  })
+})

--- a/src/screens/Login/LoginForm.tsx
+++ b/src/screens/Login/LoginForm.tsx
@@ -291,7 +291,13 @@ export const LoginForm = ({
           variant="solid"
           color="secondary"
           size="large"
-          onPress={onPressBack}>
+          onPress={() => {
+            // Leaving the screen must also drop any pending sign-in. Its
+            // redirect listener would otherwise stay armed and race the next
+            // attempt for the same single-use authorization state.
+            abortRef.current?.abort()
+            onPressBack()
+          }}>
           <ButtonText>
             <Trans>Back</Trans>
           </ButtonText>

--- a/src/screens/Login/LoginForm.tsx
+++ b/src/screens/Login/LoginForm.tsx
@@ -1,4 +1,4 @@
-import {useRef, useState} from 'react'
+import {useEffect, useRef, useState} from 'react'
 import {Keyboard, LayoutAnimation, Platform, View} from 'react-native'
 import {type ComAtprotoServerDescribeServer} from '@atproto/api'
 import {msg} from '@lingui/core/macro'
@@ -53,6 +53,13 @@ export const LoginForm = ({
   const t = useTheme()
   const {_} = useLingui()
   const {login} = useSessionApi()
+
+  // Drop any pending sign-in when the screen goes away. Hardware back and the
+  // header back button pop this form without routing through onPressBack, so
+  // anything hung off a press handler would leave the redirect listener armed —
+  // and a stale listener matches on URL shape alone, so it would swallow the
+  // *next* attempt's redirect and spend its authorization state.
+  useEffect(() => () => abortRef.current?.abort(), [])
 
   const onPressNext = async () => {
     if (isProcessing || processingRef.current) return
@@ -291,13 +298,7 @@ export const LoginForm = ({
           variant="solid"
           color="secondary"
           size="large"
-          onPress={() => {
-            // Leaving the screen must also drop any pending sign-in. Its
-            // redirect listener would otherwise stay armed and race the next
-            // attempt for the same single-use authorization state.
-            abortRef.current?.abort()
-            onPressBack()
-          }}>
+          onPress={onPressBack}>
           <ButtonText>
             <Trans>Back</Trans>
           </ButtonText>

--- a/src/state/session/oauth-client.ts
+++ b/src/state/session/oauth-client.ts
@@ -20,16 +20,34 @@ export function isOAuthCallbackUrl(url: string): boolean {
   return OAUTH_CALLBACK_RE.test(url)
 }
 
+function redirectQuery(url: string): URLSearchParams {
+  return new URLSearchParams(
+    url.includes('?') ? url.slice(url.indexOf('?') + 1) : '',
+  )
+}
+
 // Exchanging a redirect consumes its one-time `state` entry from the OAuth
-// client's store, so exactly one handler may act on a given URL. Two are armed
-// whenever the app is alive: the in-flight `signInNativeAndroid` listener, and
-// the cold-start recovery in `useNativeOAuthRedirect`. Both claim here first;
-// the loser backs off instead of calling `callback()` on spent state.
-const claimedRedirects = new Set<string>()
+// client's store, so exactly one handler may act on a given redirect. Two are
+// armed whenever the app is alive: the in-flight `signInNativeAndroid`
+// listener, and the cold-start recovery in `useNativeOAuthRedirect`. Both claim
+// here first; the loser backs off instead of calling `callback()` on spent
+// state.
+//
+// Keyed on `state` rather than the URL because `state` *is* the contested
+// resource — it is what `callback()` deletes — and because the two claimants do
+// not read the URL from the same place: `signInNativeAndroid` takes React
+// Native's `'url'` event while the recovery hook takes Expo's separate
+// `getLinkingURL()`. Nothing guarantees those strings match byte for byte, and
+// this URI is already known to vary by a slash (see OAUTH_CALLBACK_RE above),
+// which URL-keyed dedupe would miss — letting both exchange the same code.
+const claimedStates = new Set<string>()
 
 export function claimOAuthRedirect(url: string): boolean {
-  if (claimedRedirects.has(url)) return false
-  claimedRedirects.add(url)
+  // No `state` should be impossible; treating the URL as its own key keeps a
+  // malformed redirect single-use rather than un-claimable.
+  const key = redirectQuery(url).get('state') ?? url
+  if (claimedStates.has(key)) return false
+  claimedStates.add(key)
   return true
 }
 
@@ -41,10 +59,8 @@ export function claimOAuthRedirect(url: string): boolean {
  */
 /* eslint-disable-next-line @typescript-eslint/no-explicit-any -- Expo OAuth types do not resolve in Linux CI */
 export async function completeOAuthRedirect(client: any, url: string) {
-  const query = url.includes('?') ? url.slice(url.indexOf('?') + 1) : ''
-  const params = new URLSearchParams(query)
   /* eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call -- ditto */
-  const {session} = await client.callback(params, {
+  const {session} = await client.callback(redirectQuery(url), {
     redirect_uri: NATIVE_REDIRECT_URI,
   })
 

--- a/src/state/session/oauth-client.ts
+++ b/src/state/session/oauth-client.ts
@@ -16,6 +16,41 @@ export const NATIVE_REDIRECT_URI = 'community.blacksky:/oauth/callback'
 // both forms rather than relying on `startsWith(NATIVE_REDIRECT_URI)`.
 const OAUTH_CALLBACK_RE = /^community\.blacksky:\/\/?oauth\/callback\b/
 
+export function isOAuthCallbackUrl(url: string): boolean {
+  return OAUTH_CALLBACK_RE.test(url)
+}
+
+// Exchanging a redirect consumes its one-time `state` entry from the OAuth
+// client's store, so exactly one handler may act on a given URL. Two are armed
+// whenever the app is alive: the in-flight `signInNativeAndroid` listener, and
+// the cold-start recovery in `useNativeOAuthRedirect`. Both claim here first;
+// the loser backs off instead of calling `callback()` on spent state.
+const claimedRedirects = new Set<string>()
+
+export function claimOAuthRedirect(url: string): boolean {
+  if (claimedRedirects.has(url)) return false
+  claimedRedirects.add(url)
+  return true
+}
+
+/**
+ * Exchange an OAuth redirect deep-link for a session.
+ *
+ * Slash-count-agnostic param extraction — do NOT rely on `new URL()`, which is
+ * fragile on Hermes for the custom `community.blacksky:` scheme.
+ */
+/* eslint-disable-next-line @typescript-eslint/no-explicit-any -- Expo OAuth types do not resolve in Linux CI */
+export async function completeOAuthRedirect(client: any, url: string) {
+  const query = url.includes('?') ? url.slice(url.indexOf('?') + 1) : ''
+  const params = new URLSearchParams(query)
+  /* eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call -- ditto */
+  const {session} = await client.callback(params, {
+    redirect_uri: NATIVE_REDIRECT_URI,
+  })
+
+  return session
+}
+
 // Debug fetch wrapper — logs all OAuth-related network requests to Metro console
 const debugFetch: typeof fetch = async (input, init) => {
   const url =
@@ -142,20 +177,14 @@ export async function signInNativeAndroid(
 
     const sub = Linking.addEventListener('url', ({url: incoming}) => {
       if (settled) return
-      if (!OAUTH_CALLBACK_RE.test(incoming)) return // ignore other deep-links
+      if (!isOAuthCallbackUrl(incoming)) return // ignore other deep-links
+      // Claimed synchronously so the cold-start handler, which can only run a
+      // tick later off a React effect, stands down for this URL.
+      if (!claimOAuthRedirect(incoming)) return
       settled = true
       cleanup()
       ;(async () => {
-        // Slash-count-agnostic param extraction — do NOT rely on `new URL()`,
-        // which is fragile on Hermes for the custom `community.blacksky:` scheme.
-        const query = incoming.includes('?')
-          ? incoming.slice(incoming.indexOf('?') + 1)
-          : ''
-        const params = new URLSearchParams(query)
-        const {session} = await client.callback(params, {
-          redirect_uri: redirectUri,
-        })
-        resolve(session)
+        resolve(await completeOAuthRedirect(client, incoming))
       })().catch(reject)
     })
 

--- a/src/state/session/useNativeOAuthRedirect.ts
+++ b/src/state/session/useNativeOAuthRedirect.ts
@@ -26,8 +26,14 @@ import {
  * `useLinkingURL()` reports the launch URL as well as later ones, so mounting
  * this recovers those sign-ins. The authorization state that `callback()` needs
  * outlives the process: @atproto/oauth-client-expo keeps it in MMKV for ten
- * minutes, which also bounds how long a detour can take before the user has to
- * start over.
+ * minutes.
+ *
+ * That MMKV TTL is not the real deadline, though. The PDS expires the
+ * authorization request after AUTHORIZATION_INACTIVITY_TIMEOUT — five minutes —
+ * refreshed only by requests to the authorization server, which a browser tab
+ * parked on the 2FA form does not make. A detour longer than five minutes comes
+ * back as `error=access_denied` no matter what the client does, so recovery here
+ * cannot be complete on its own.
  */
 export function useNativeOAuthRedirect() {
   const incomingUrl = Linking.useLinkingURL()

--- a/src/state/session/useNativeOAuthRedirect.ts
+++ b/src/state/session/useNativeOAuthRedirect.ts
@@ -1,0 +1,62 @@
+import {useEffect} from 'react'
+import * as Linking from 'expo-linking'
+
+import {logger} from '#/logger'
+import {useSessionApi} from '#/state/session'
+import {
+  claimOAuthRedirect,
+  completeOAuthRedirect,
+  getOAuthClient,
+  isOAuthCallbackUrl,
+} from '#/state/session/oauth-client'
+
+/**
+ * Completes a native OAuth sign-in whose redirect arrived without an in-flight
+ * `signInNativeAndroid` waiting for it.
+ *
+ * The sign-in helper listens for the redirect with `Linking.addEventListener`,
+ * which only ever sees URLs delivered to a *running* app. That is enough while
+ * the app stays alive, but the 2FA flow forces the user out to an email app to
+ * fetch a code, and Android is free to kill our backgrounded process while they
+ * are gone. The redirect then cold-starts the app, where the listener does not
+ * exist yet and the launch URL is only reachable via the initial-URL APIs — so
+ * the callback landed nowhere and the user was dropped on the logged-out screen
+ * with their sign-in silently abandoned.
+ *
+ * `useLinkingURL()` reports the launch URL as well as later ones, so mounting
+ * this recovers those sign-ins. The authorization state that `callback()` needs
+ * outlives the process: @atproto/oauth-client-expo keeps it in MMKV for ten
+ * minutes, which also bounds how long a detour can take before the user has to
+ * start over.
+ */
+export function useNativeOAuthRedirect() {
+  const incomingUrl = Linking.useLinkingURL()
+  const {login} = useSessionApi()
+
+  useEffect(() => {
+    if (!incomingUrl || !isOAuthCallbackUrl(incomingUrl)) return
+    // A live signInNativeAndroid claims the URL first and completes it itself;
+    // the exchange is single-use, so only one of us may run it.
+    if (!claimOAuthRedirect(incomingUrl)) return
+
+    logger.warn('oauth: completing native redirect outside of sign-in flow')
+    void (async () => {
+      try {
+        const session = await completeOAuthRedirect(
+          getOAuthClient(),
+          incomingUrl,
+        )
+        await login(
+          {service: '', identifier: '', password: '', oauthSession: session},
+          'LoginForm',
+        )
+      } catch (e) {
+        // Most likely the ten-minute authorization window elapsed while the
+        // user was away, which cannot be recovered without a fresh sign-in.
+        logger.error('oauth: native redirect recovery failed', {
+          error: String(e),
+        })
+      }
+    })()
+  }, [incomingUrl, login])
+}

--- a/src/view/shell/index.tsx
+++ b/src/view/shell/index.tsx
@@ -15,6 +15,7 @@ import {AppviewFallbackController} from '#/state/appview-fallback-controller'
 import {useDialogFullyExpandedCountContext} from '#/state/dialogs'
 import {useProfileEnrichment} from '#/state/queries/profile-enrichment'
 import {useSession} from '#/state/session'
+import {useNativeOAuthRedirect} from '#/state/session/useNativeOAuthRedirect'
 import {
   useIsDrawerOpen,
   useIsDrawerSwipeDisabled,
@@ -200,6 +201,7 @@ export function Shell() {
   const fullyExpandedCount = useDialogFullyExpandedCountContext()
 
   useIntentHandler()
+  useNativeOAuthRedirect()
 
   useEffect(() => {
     setSystemUITheme('theme', t)


### PR DESCRIPTION
Follow-up to #144. That fix made sign-in ignore Android's phantom `dismiss` and wait for the redirect deep-link, but it waits with `Linking.addEventListener`, which only sees URLs delivered to an already-running app. The 2FA flow sends the user out to an email app for a code, and Android is free to kill our backgrounded process while they are gone — the redirect then cold-starts the app, no listener exists yet, and the sign-in is silently abandoned.

Completes those sign-ins from the launch URL via `useLinkingURL()`, with a claim registry so the in-flight listener and the cold-start path can't both spend the same single-use authorization state. Also aborts a pending attempt when leaving the login screen, which otherwise leaked an armed listener into the next attempt.