### PR TITLE
feat(search): flag to route search and feed discovery to the Bluesky appview

### DIFF
--- a/src/analytics/features/types.ts
+++ b/src/analytics/features/types.ts
@@ -16,6 +16,7 @@ export enum Features {
   NotificationsExpandedProfileCardEnable = 'notifications:expanded_profile_card:enable',
   AppviewFallbackMode = 'appview_fallback:mode',
   AppviewFallbackThresholds = 'appview_fallback:thresholds',
+  SearchAppviewRoute = 'search_appview:route',
 
   AATest = 'aa-test',
 }

--- a/src/lib/api/search-routing.ts
+++ b/src/lib/api/search-routing.ts
@@ -1,0 +1,15 @@
+import {BLUESKY_APPVIEW_PINNED_OPTS} from '#/lib/constants'
+import {Features, features} from '#/analytics/features'
+
+/**
+ * Route search and feed-discovery reads to the Bluesky appview when the
+ * `search_appview:route` flag is set to 'bluesky', to shed search load off the
+ * home appview. Defaults to 'home', which returns empty opts so the call
+ * follows the agent's current proxy header (home, or the global fallback
+ * target during an outage). Read at call time so a flag flip takes effect on
+ * the next query without a reload.
+ */
+export function searchAppviewOpts() {
+  const route = features.getFeatureValue(Features.SearchAppviewRoute, 'home')
+  return route === 'bluesky' ? BLUESKY_APPVIEW_PINNED_OPTS : {}
+}

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -230,6 +230,10 @@ export const HOME_APPVIEW_PINNED_OPTS = {
   headers: {'atproto-proxy': HOME_PROXY_HEADER},
 }
 
+export const BLUESKY_APPVIEW_PINNED_OPTS = {
+  headers: {'atproto-proxy': BLUESKY_FALLBACK_PROXY_HEADER},
+}
+
 export const DEV_ENV_APPVIEW = `http://localhost:2584` // always the same
 
 // temp hack for e2e - esb

--- a/src/state/queries/actor-autocomplete.ts
+++ b/src/state/queries/actor-autocomplete.ts
@@ -6,6 +6,7 @@ import {
 } from '@atproto/api'
 import {keepPreviousData, useQuery, useQueryClient} from '@tanstack/react-query'
 
+import {searchAppviewOpts} from '#/lib/api/search-routing'
 import {isJustAMute, moduiContainsHideableOffense} from '#/lib/moderation'
 import {logger} from '#/logger'
 import {STALE} from '#/state/queries'
@@ -40,10 +41,13 @@ export function useActorAutocompleteQuery(
     queryKey: RQKEY(prefix || ''),
     async queryFn() {
       const res = prefix
-        ? await agent.searchActorsTypeahead({
-            q: prefix,
-            limit: limit || 8,
-          })
+        ? await agent.searchActorsTypeahead(
+            {
+              q: prefix,
+              limit: limit || 8,
+            },
+            searchAppviewOpts(),
+          )
         : undefined
       return res?.data.actors || []
     },
@@ -77,10 +81,13 @@ export function useActorAutocompleteFn() {
             staleTime: STALE.MINUTES.ONE,
             queryKey: RQKEY(query || ''),
             queryFn: () =>
-              agent.searchActorsTypeahead({
-                q: query,
-                limit,
-              }),
+              agent.searchActorsTypeahead(
+                {
+                  q: query,
+                  limit,
+                },
+                searchAppviewOpts(),
+              ),
           })
         } catch (e) {
           logger.error('useActorSearch: searchActorsTypeahead failed', {

--- a/src/state/queries/actor-search.ts
+++ b/src/state/queries/actor-search.ts
@@ -7,6 +7,7 @@ import {
   useInfiniteQuery,
 } from '@tanstack/react-query'
 
+import {searchAppviewOpts} from '#/lib/api/search-routing'
 import {STALE} from '#/state/queries'
 import {useAgent} from '#/state/session'
 
@@ -39,11 +40,14 @@ export function useActorSearch({
     staleTime: STALE.MINUTES.FIVE,
     queryKey: RQKEY(query, limit),
     queryFn: async ({pageParam}) => {
-      const res = await agent.searchActors({
-        q: query,
-        limit,
-        cursor: pageParam,
-      })
+      const res = await agent.searchActors(
+        {
+          q: query,
+          limit,
+          cursor: pageParam,
+        },
+        searchAppviewOpts(),
+      )
       return res.data
     },
     enabled: enabled && !!query,

--- a/src/state/queries/feed.ts
+++ b/src/state/queries/feed.ts
@@ -22,6 +22,7 @@ import {
 } from '@tanstack/react-query'
 
 import {getProxyHeadersForFeed} from '#/lib/api/feed/utils'
+import {searchAppviewOpts} from '#/lib/api/search-routing'
 import {useBrand} from '#/lib/community/BrandContext'
 import {DEFAULT_DISCOVERY_FEEDS} from '#/lib/community/configGenerator'
 import {DISCOVER_FEED_URI, DISCOVER_SAVED_FEED} from '#/lib/constants'
@@ -270,10 +271,13 @@ export function useGetPopularFeedsQuery(options?: GetPopularFeedsOptions) {
     enabled: Boolean(moderationOpts) && options?.enabled !== false,
     queryKey: createGetPopularFeedsQueryKey(options),
     queryFn: async ({pageParam}) => {
-      const res = await agent.app.bsky.unspecced.getPopularFeedGenerators({
-        limit,
-        cursor: pageParam,
-      })
+      const res = await agent.app.bsky.unspecced.getPopularFeedGenerators(
+        {
+          limit,
+          cursor: pageParam,
+        },
+        searchAppviewOpts(),
+      )
 
       // precache feeds
       for (const feed of res.data.feeds) {
@@ -451,10 +455,13 @@ export function useSearchPopularFeedsMutation() {
 
   return useMutation({
     mutationFn: async (query: string) => {
-      const res = await agent.app.bsky.unspecced.getPopularFeedGenerators({
-        limit: 10,
-        query: query,
-      })
+      const res = await agent.app.bsky.unspecced.getPopularFeedGenerators(
+        {
+          limit: 10,
+          query: query,
+        },
+        searchAppviewOpts(),
+      )
 
       if (moderationOpts) {
         return res.data.feeds.filter(feed => {
@@ -489,10 +496,13 @@ export function usePopularFeedsSearch({
     enabled: enabledInner,
     queryKey: createPopularFeedsSearchQueryKey(query),
     queryFn: async () => {
-      const res = await agent.app.bsky.unspecced.getPopularFeedGenerators({
-        limit: 15,
-        query: query,
-      })
+      const res = await agent.app.bsky.unspecced.getPopularFeedGenerators(
+        {
+          limit: 15,
+          query: query,
+        },
+        searchAppviewOpts(),
+      )
 
       return res.data.feeds
     },

--- a/src/state/queries/search-posts.ts
+++ b/src/state/queries/search-posts.ts
@@ -13,6 +13,7 @@ import {
   useInfiniteQuery,
 } from '@tanstack/react-query'
 
+import {searchAppviewOpts} from '#/lib/api/search-routing'
 import {useModerationOpts} from '#/state/preferences/moderation-opts'
 import {useAgent} from '#/state/session'
 import {
@@ -61,12 +62,15 @@ export function useSearchPostsQuery({
   >({
     queryKey: searchPostsQueryKey({query, sort}),
     queryFn: async ({pageParam}) => {
-      const res = await agent.app.bsky.feed.searchPosts({
-        q: query,
-        limit: 25,
-        cursor: pageParam,
-        sort,
-      })
+      const res = await agent.app.bsky.feed.searchPosts(
+        {
+          q: query,
+          limit: 25,
+          cursor: pageParam,
+          sort,
+        },
+        searchAppviewOpts(),
+      )
       return res.data
     },
     initialPageParam: undefined,


### PR DESCRIPTION
## What

Adds a GrowthBook feature flag **`search_appview:route`** (`home` | `bluesky`, default `home`) that controls which appview serves search and feed-discovery reads. This is the client-side switch for **offloading search entirely to the Bluesky appview** (so the Blacksky search backend can be retired).

When set to `bluesky`, every search / typeahead / feed-discovery call is pinned to the public Bluesky appview instead of the home appview:

- `app.bsky.actor.searchActors` — actor search + starter-pack profile search
- `app.bsky.actor.searchActorsTypeahead` — top-bar typeahead **and** composer mention autocomplete
- `app.bsky.feed.searchPosts`
- `app.bsky.unspecced.getPopularFeedGenerators` — popular list + feed search

Default `home` preserves today's behavior: calls follow the agent's current proxy header, so they still ride the existing `appview_fallback:mode` routing during an outage. `bluesky` is an always-pin override on top of that. Rollout order: flip the flag, verify, then retire the Blacksky search backend.

## Implementation

- New `searchAppviewOpts()` helper reads the flag at call time and returns per-call `atproto-proxy` header opts (mirrors the existing `HOME_APPVIEW_PINNED_OPTS` pinning pattern). Flag flips take effect on the next query, no reload.
- Covers **all** search call sites, including two that are easy to miss: the `components/Autocomplete` composer-mention hook and starter-pack generation.
- Home-curated discovery feeds fetched by explicit URI (`getFeedGenerators`) are intentionally left on the home appview.

## Moderation note

Routing search to Bluesky means search results reflect **Bluesky's** takedown/ban list, not Blacksky's. Accounts banned on Bluesky but allowed on Blacksky will no longer appear in search; this is the intended behavior when retiring the Blacksky search backend.

## Testing

- \`yarn typecheck\` — clean
- \`yarn lint\` on changed files — clean