### PR TITLE
feat(search): route composer mention and starter-pack actor search to the appview flag

### DIFF
--- a/src/components/Autocomplete/useAutocomplete/index.ts
+++ b/src/components/Autocomplete/useAutocomplete/index.ts
@@ -2,6 +2,7 @@ import {useCallback, useMemo} from 'react'
 import {moderateProfile, type ModerationOpts} from '@atproto/api'
 import {keepPreviousData, useQuery} from '@tanstack/react-query'
 
+import {searchAppviewOpts} from '#/lib/api/search-routing'
 import {isJustAMute, moduiContainsHideableOffense} from '#/lib/moderation'
 import {useModerationOpts} from '#/state/preferences/moderation-opts'
 import {STALE} from '#/state/queries'
@@ -52,10 +53,13 @@ export function useAutocomplete({
         // Going from "foo" to "foo." should not clear matches.
         q = q.toLowerCase().trim().replace(/\.$/, '')
 
-        const res = await agent.searchActorsTypeahead({
-          q,
-          limit: limit || 8,
-        })
+        const res = await agent.searchActorsTypeahead(
+          {
+            q,
+            limit: limit || 8,
+          },
+          searchAppviewOpts(),
+        )
 
         return (res?.data.actors || []).map(profile => ({
           key: profile.did,

--- a/src/lib/generate-starterpack.ts
+++ b/src/lib/generate-starterpack.ts
@@ -10,6 +10,7 @@ import {msg} from '@lingui/core/macro'
 import {useLingui} from '@lingui/react'
 import {useMutation} from '@tanstack/react-query'
 
+import {searchAppviewOpts} from '#/lib/api/search-routing'
 import {until} from '#/lib/async/until'
 import {sanitizeDisplayName} from '#/lib/strings/display-names'
 import {sanitizeHandle} from '#/lib/strings/handles'
@@ -77,10 +78,13 @@ export function useGenerateStarterPackMutation({
         })(),
         (async () => {
           profiles = (
-            await agent.app.bsky.actor.searchActors({
-              q: encodeURIComponent('*'),
-              limit: 49,
-            })
+            await agent.app.bsky.actor.searchActors(
+              {
+                q: encodeURIComponent('*'),
+                limit: 49,
+              },
+              searchAppviewOpts(),
+            )
           ).data.actors.filter(p => p.viewer?.following)
         })(),
       ])


### PR DESCRIPTION
## What

Follow-up to #167. That PR routed the main search surfaces through the `search_appview:route` flag, but two `searchActors*` call sites were missed and still hit the home appview unconditionally:

- **Composer mention autocomplete** — `components/Autocomplete/useAutocomplete` (a separate hook from the one #167 covered)
- **Starter-pack generation** — `lib/generate-starterpack.ts` profile search

Both now go through `searchAppviewOpts()`, so setting `search_appview:route=bluesky` moves **all** search traffic off the home appview — required for retiring the Blacksky search backend.

## Behavior

Default (`home`) is unchanged. When the flag is `bluesky`, these two paths pin to the public Bluesky appview like the rest of search.

## Testing

- \`yarn typecheck\` — clean
- lint (pre-commit hook) — clean