### PR TITLE
fix(ogcard): restore starter-pack record type narrowing

### DIFF
--- a/bskyogcard/package.json
+++ b/bskyogcard/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bskyogcard",
-  "version": "0.0.0",
+  "version": "0.0.1",
   "type": "module",
   "main": "src/index.ts",
   "devEngines": {

--- a/bskyogcard/src/components/StarterPack.tsx
+++ b/bskyogcard/src/components/StarterPack.tsx
@@ -3,6 +3,7 @@ import {type AppBskyGraphDefs, AppBskyGraphStarterpack} from '@atproto/api'
 
 import {Cluster} from './Cluster.js'
 import {Img} from './Img.js'
+import * as bsky from '../types/bsky/index.js'
 
 export const STARTERPACK_HEIGHT = 630
 export const STARTERPACK_WIDTH = 1200
@@ -19,7 +20,10 @@ export function StarterPack(props: {
   images: Map<string, Buffer>
 }) {
   const {starterPack, images} = props
-  const record = AppBskyGraphStarterpack.isRecord(starterPack.record)
+  const record = bsky.dangerousIsType<AppBskyGraphStarterpack.Record>(
+    starterPack.record,
+    AppBskyGraphStarterpack.isRecord,
+  )
     ? starterPack.record
     : null
   const imagesArray = [...images.values()]


### PR DESCRIPTION
## Summary

`bskyogcard` renders OpenGraph preview images. This restores proper type narrowing of the starter-pack record so `record.name` resolves to `string` instead of `unknown`, which the TypeScript build (`tsc`) requires.

`@atproto/api`'s `isRecord` only asserts the `$type` string, not the full object schema, so a bare `isRecord(...)` guard leaves `record.name` typed `unknown` — failing `tsc` (TS18046 + TS2322) and therefore the production Docker build. Wrapping the check in the existing `dangerousIsType<Record>()` helper restores the field types, matching the upstream pattern.

## Test plan

- [ ] `pnpm typecheck` passes
- [ ] `pnpm build` completes
- [ ] Docker image builds from `Dockerfile.bskyogcard`
- [ ] Starter-pack OG card image renders