### PR TITLE
fix(search): default appview routing to Bluesky

### DIFF
--- a/src/lib/api/search-routing.ts
+++ b/src/lib/api/search-routing.ts
@@ -4,12 +4,11 @@ import {Features, features} from '#/analytics/features'
 /**
  * Route search and feed-discovery reads to the Bluesky appview when the
  * `search_appview:route` flag is set to 'bluesky', to shed search load off the
- * home appview. Defaults to 'home', which returns empty opts so the call
- * follows the agent's current proxy header (home, or the global fallback
- * target during an outage). Read at call time so a flag flip takes effect on
- * the next query without a reload.
+ * home appview. Defaults to 'bluesky' because the home appview no longer serves
+ * search. Read at call time so a flag flip takes effect on the next query
+ * without a reload.
  */
 export function searchAppviewOpts() {
-  const route = features.getFeatureValue(Features.SearchAppviewRoute, 'home')
+  const route = features.getFeatureValue(Features.SearchAppviewRoute, 'bluesky')
   return route === 'bluesky' ? BLUESKY_APPVIEW_PINNED_OPTS : {}
 }


### PR DESCRIPTION
## Summary

Default search AppView routing to Bluesky while feature configuration is loading, preventing actor autocomplete from reaching an unavailable home search endpoint. Explicit routing flag values continue to apply once loaded.

## Test plan

- [ ] Search for an account from the new-DM picker during app startup
- [ ] Confirm results load without a network error