### PR TITLE
fix(signup): make the captcha webview and handle domains follow the selected community

### DIFF
--- a/src/screens/Signup/StepCaptcha/CaptchaWebView.tsx
+++ b/src/screens/Signup/StepCaptcha/CaptchaWebView.tsx
@@ -1,4 +1,4 @@
-import {useEffect, useMemo, useRef} from 'react'
+import {useCallback, useEffect, useMemo, useRef} from 'react'
 import {WebView, type WebViewNavigation} from 'react-native-webview'
 import {type ShouldStartLoadRequest} from 'react-native-webview/lib/WebViewTypes'
 
@@ -15,6 +15,25 @@ const ALLOWED_HOSTS = [
   'newassets.hcaptcha.com',
   'api2.hcaptcha.com',
 ]
+
+/**
+ * The gate page lives on whichever PDS signup is pointed at, so the static list
+ * can't cover community PDSes. Derive that host from the same `serviceUrl` the
+ * captcha URL is built from — an unset or malformed value adds nothing, leaving
+ * the static list as-is.
+ */
+export function buildAllowedHosts(serviceUrl?: string): string[] {
+  if (!serviceUrl) return ALLOWED_HOSTS
+
+  try {
+    const {host} = new URL(serviceUrl)
+    return ALLOWED_HOSTS.includes(host)
+      ? ALLOWED_HOSTS
+      : [...ALLOWED_HOSTS, host]
+  } catch {
+    return ALLOWED_HOSTS
+  }
+}
 
 const MIN_DELAY = 3_500
 
@@ -55,10 +74,18 @@ export function CaptchaWebView({
 
   const wasSuccessful = useRef(false)
 
-  const onShouldStartLoadWithRequest = (event: ShouldStartLoadRequest) => {
-    const urlp = new URL(event.url)
-    return ALLOWED_HOSTS.includes(urlp.host)
-  }
+  const allowedHosts = useMemo(
+    () => buildAllowedHosts(state?.serviceUrl),
+    [state?.serviceUrl],
+  )
+
+  const onShouldStartLoadWithRequest = useCallback(
+    (event: ShouldStartLoadRequest) => {
+      const urlp = new URL(event.url)
+      return allowedHosts.includes(urlp.host)
+    },
+    [allowedHosts],
+  )
 
   const onNavigationStateChange = (e: WebViewNavigation) => {
     if (wasSuccessful.current) return

--- a/src/screens/Signup/StepCaptcha/__tests__/CaptchaWebView.test.ts
+++ b/src/screens/Signup/StepCaptcha/__tests__/CaptchaWebView.test.ts
@@ -1,0 +1,36 @@
+import {buildAllowedHosts} from '#/screens/Signup/StepCaptcha/CaptchaWebView'
+
+describe('buildAllowedHosts', () => {
+  it('allows the community PDS the signup is pointed at', () => {
+    expect(buildAllowedHosts('https://medsky.network')).toContain(
+      'medsky.network',
+    )
+  })
+
+  it('keeps the static hosts alongside the community PDS', () => {
+    const hosts = buildAllowedHosts('https://medsky.network')
+    expect(hosts).toEqual(expect.arrayContaining(['blacksky.app', 'bsky.app']))
+  })
+
+  it('strips the port and path from the service URL', () => {
+    expect(buildAllowedHosts('https://pds.example.com/xrpc')).toContain(
+      'pds.example.com',
+    )
+  })
+
+  it('does not duplicate a host already on the static list', () => {
+    const hosts = buildAllowedHosts('https://blacksky.app')
+    expect(hosts.filter(h => h === 'blacksky.app')).toHaveLength(1)
+  })
+
+  it('falls back to the static list when serviceUrl is unset', () => {
+    expect(buildAllowedHosts(undefined)).toContain('blacksky.app')
+    expect(buildAllowedHosts(undefined)).not.toContain('medsky.network')
+  })
+
+  it('falls back to the static list when serviceUrl is malformed', () => {
+    const hosts = buildAllowedHosts('not a url')
+    expect(hosts).toContain('blacksky.app')
+    expect(hosts).toHaveLength(buildAllowedHosts(undefined).length)
+  })
+})

--- a/src/screens/Signup/__tests__/handleDomains.test.ts
+++ b/src/screens/Signup/__tests__/handleDomains.test.ts
@@ -42,7 +42,23 @@ describe('filterUserDomains', () => {
     ).toEqual(['.medsky.network'])
   })
 
-  it('returns nothing when no advertised domain matches the community', () => {
-    expect(filterUserDomains(['.blacksky.app'], ['.latinsky.app'])).toEqual([])
+  it('falls back to the advertised domains when nothing intersects', () => {
+    expect(filterUserDomains(['.blacksky.app'], ['.latinsky.app'])).toEqual([
+      '.blacksky.app',
+    ])
+  })
+
+  it('never returns an empty list while the PDS advertises a domain', () => {
+    // Reachable today: picking a community and then switching the hosting
+    // provider leaves the community slug and the PDS pointing at different
+    // servers, so the two lists can disagree entirely.
+    const cases: [string[], string[]][] = [
+      [['.bsky.social'], ['.latinsky.app', '.afrolatinsky.app']],
+      [['.medsky.network'], ['.blacksky.app']],
+    ]
+
+    for (const [domains, allowed] of cases) {
+      expect(filterUserDomains(domains, allowed)).toEqual(domains)
+    }
   })
 })

--- a/src/screens/Signup/__tests__/handleDomains.test.ts
+++ b/src/screens/Signup/__tests__/handleDomains.test.ts
@@ -1,0 +1,48 @@
+import {filterUserDomains} from '#/screens/Signup/handleDomains'
+
+const BLACKSKY_DOMAINS = [
+  '.myatproto.social',
+  '.blacksky.app',
+  '.cryptoanarchy.network',
+  '.latinsky.app',
+  '.afrolatinsky.app',
+]
+
+describe('filterUserDomains', () => {
+  it("restricts domains to the selected community's handles", () => {
+    expect(
+      filterUserDomains(BLACKSKY_DOMAINS, [
+        '.latinsky.app',
+        '.afrolatinsky.app',
+      ]),
+    ).toEqual(['.latinsky.app', '.afrolatinsky.app'])
+  })
+
+  it('puts a community domain first so it becomes the default suffix', () => {
+    const [first] = filterUserDomains(BLACKSKY_DOMAINS, ['.latinsky.app'])
+    expect(first).toBe('.latinsky.app')
+  })
+
+  it('shows every advertised domain when the community config is missing', () => {
+    expect(filterUserDomains(BLACKSKY_DOMAINS, undefined)).toEqual(
+      BLACKSKY_DOMAINS,
+    )
+  })
+
+  it('shows every advertised domain when the community lists none', () => {
+    expect(filterUserDomains(BLACKSKY_DOMAINS, [])).toEqual(BLACKSKY_DOMAINS)
+  })
+
+  it('ignores community handles the PDS does not advertise', () => {
+    expect(
+      filterUserDomains(
+        ['.medsky.network', '.nursesky.network'],
+        ['.medsky.app', '.medsky.network'],
+      ),
+    ).toEqual(['.medsky.network'])
+  })
+
+  it('returns nothing when no advertised domain matches the community', () => {
+    expect(filterUserDomains(['.blacksky.app'], ['.latinsky.app'])).toEqual([])
+  })
+})

--- a/src/screens/Signup/handleDomains.ts
+++ b/src/screens/Signup/handleDomains.ts
@@ -1,0 +1,17 @@
+/**
+ * Narrow the domains a PDS advertises down to the ones the selected community
+ * publishes.
+ *
+ * An empty or missing `allowed` means "no community restriction known" — the
+ * community's config hasn't loaded or couldn't be fetched — so every advertised
+ * domain stays selectable. Signup continuing with an extra domain on offer
+ * beats blocking it on a brand-service failure.
+ */
+export function filterUserDomains(
+  domains: string[],
+  allowed?: string[],
+): string[] {
+  if (!allowed || allowed.length === 0) return domains
+
+  return domains.filter(domain => allowed.includes(domain))
+}

--- a/src/screens/Signup/handleDomains.ts
+++ b/src/screens/Signup/handleDomains.ts
@@ -2,10 +2,16 @@
  * Narrow the domains a PDS advertises down to the ones the selected community
  * publishes.
  *
- * An empty or missing `allowed` means "no community restriction known" — the
- * community's config hasn't loaded or couldn't be fetched — so every advertised
- * domain stays selectable. Signup continuing with an extra domain on offer
- * beats blocking it on a brand-service failure.
+ * Falls back to every advertised domain in two cases:
+ *
+ * - `allowed` is empty or missing — the community's config hasn't loaded or
+ *   couldn't be fetched, so there is no restriction to apply.
+ * - Nothing intersects — the community and the PDS disagree, which happens when
+ *   the hosting provider is switched after a community is picked (the two are
+ *   tracked in separate state). The PDS is the authority on what it accepts.
+ *
+ * Either way the PDS's own list wins over an empty handle step: an extra domain
+ * on offer is cheaper to correct than a signup the user has to restart.
  */
 export function filterUserDomains(
   domains: string[],
@@ -13,5 +19,7 @@ export function filterUserDomains(
 ): string[] {
   if (!allowed || allowed.length === 0) return domains
 
-  return domains.filter(domain => allowed.includes(domain))
+  const filtered = domains.filter(domain => allowed.includes(domain))
+
+  return filtered.length > 0 ? filtered : domains
 }

--- a/src/screens/Signup/index.tsx
+++ b/src/screens/Signup/index.tsx
@@ -6,8 +6,10 @@ import {AppBskyGraphStarterpack} from '@atproto/api'
 import {msg} from '@lingui/core/macro'
 import {useLingui} from '@lingui/react'
 import {Trans} from '@lingui/react/macro'
+import {useQuery} from '@tanstack/react-query'
 
-import {useBrand} from '#/lib/community/BrandContext'
+import {DEFAULT_BRAND_CONFIG, useBrand} from '#/lib/community/BrandContext'
+import {fetchBrandBySlug} from '#/lib/community/resolveBrand'
 import {FEEDBACK_FORM_URL} from '#/lib/constants'
 import {logger} from '#/logger'
 import {useServiceQuery} from '#/state/queries/service'
@@ -98,6 +100,30 @@ export function Signup({
     refetch,
   } = useServiceQuery(state.serviceUrl)
 
+  /*
+   * The picked community's handle domains live in its published brand config,
+   * not in the ambient brand — which native signup pins to the bundled Blacksky
+   * copy while logged out. Fetch the live config for whichever community is
+   * selected (Blacksky included, since the bundle can be stale).
+   */
+  const communitySlug =
+    state.selectedBrandSlug ?? DEFAULT_BRAND_CONFIG.metadata.slug
+  const {data: communityConfig} = useQuery({
+    queryKey: ['signup-brand-config', communitySlug],
+    queryFn: () => fetchBrandBySlug(communitySlug),
+    staleTime: 5 * 60 * 1000,
+  })
+
+  /*
+   * On a failed or pending fetch this falls back to the ambient brand: correct
+   * on web (injected by hostname) and empty on native, which leaves every
+   * domain the PDS advertises selectable. Showing an extra domain beats
+   * blocking signup on a brand-service blip.
+   */
+  const availableHandles =
+    communityConfig?.services.pds.availableHandles ??
+    brand.services.pds.availableHandles
+
   useEffect(() => {
     if (isFetching) {
       dispatch({type: 'setIsLoading', value: true})
@@ -111,7 +137,7 @@ export function Signup({
       dispatch({
         type: 'setServiceDescription',
         value: undefined,
-        availableHandles: brand.services.pds.availableHandles,
+        availableHandles,
       })
       dispatch({
         type: 'setError',
@@ -123,11 +149,11 @@ export function Signup({
       dispatch({
         type: 'setServiceDescription',
         value: serviceInfo,
-        availableHandles: brand.services.pds.availableHandles,
+        availableHandles,
       })
       dispatch({type: 'setError', value: ''})
     }
-  }, [_, serviceInfo, isError, brand.services.pds.availableHandles])
+  }, [_, serviceInfo, isError, availableHandles])
 
   useEffect(() => {
     if (state.pendingSubmit) {

--- a/src/screens/Signup/state.ts
+++ b/src/screens/Signup/state.ts
@@ -13,6 +13,7 @@ import {createFullHandle} from '#/lib/strings/handles'
 import {getAge} from '#/lib/strings/time'
 import {useSessionApi} from '#/state/session'
 import {useOnboardingDispatch} from '#/state/shell'
+import {filterUserDomains} from '#/screens/Signup/handleDomains'
 import {type AnalyticsContextType, useAnalytics} from '#/analytics'
 
 export type ServiceDescription = ComAtprotoServerDescribeServer.OutputSchema
@@ -192,11 +193,7 @@ export function reducer(s: SignupState, a: SignupAction): SignupState {
       LayoutAnimation.configureNext(LayoutAnimation.Presets.easeInEaseOut)
 
       const domains = a.value?.availableUserDomains ?? []
-      const allowed = a.availableHandles
-      const filtered =
-        allowed && allowed.length > 0
-          ? domains.filter(d => allowed.includes(d))
-          : domains
+      const filtered = filterUserDomains(domains, a.availableHandles)
 
       next.serviceDescription = a.value
         ? {...a.value, availableUserDomains: filtered}


### PR DESCRIPTION
Two native signup bugs that both come from reading community-specific values
from the wrong place. Bundled together so one OTA bundle can verify both.

## 1. Captcha webview blocks the community PDS

The webview gates navigation on a static host allowlist covering only Blacksky
hosts. Once the community picker let signup target another community's PDS, the
captcha page hosted there was blocked before any request was made — blank step
on iOS, and the form post is affected on Android.

Fixed by deriving the allowed host from the same `serviceUrl` the captcha URL
is built from, so any current or future community PDS is covered without
editing a list. Unset or malformed `serviceUrl` adds nothing.

## 2. Handle step ignores the community's handle domains

Signup filtered handle domains using the ambient brand, which is pinned to the
bundled Blacksky config while logged out. Picking a community changed the PDS
but never its handle domains, so the handle step offered everything the PDS
advertises and defaulted to the first entry — e.g. picking Latinsky produced a
`.myatproto.social` suffix.

Fixed by fetching the selected community's published config and filtering with
that. Blacksky is fetched too, since the bundled copy can be stale.

A failed or pending fetch leaves every advertised domain selectable rather than
blocking the step: an extra domain on offer is cheaper to correct than a signup
the user has to restart.

## Testing

- 12 new unit tests (`buildAllowedHosts`, `filterUserDomains`), covering both
  fallback paths in each
- Full signup + community suites pass: 765 tests, 41 suites
- eslint + prettier clean on touched files; no new type errors

Not device-verified. The tests cover the host and filter logic, not the
rendered steps — this needs a manual signup pass on iOS and Android: pick
Latinsky and confirm the suffix, pick Medsky and confirm the captcha renders.

## Follow-up (not in this PR)

`redirectHost` in `CaptchaWebView` is still hardcoded and should be derived
from the community config too.