### PR TITLE
chore(ci): make the EAS update workflow dispatch-only

### DIFF
--- a/.github/workflows/bundle-deploy-eas-update.yml
+++ b/.github/workflows/bundle-deploy-eas-update.yml
@@ -2,9 +2,6 @@
 name: Bundle and Deploy EAS Update
 
 on:
-  push:
-    branches:
-      - main
   workflow_dispatch:
     inputs:
       channel:


### PR DESCRIPTION
## Summary

`bundle-deploy-eas-update.yml` published an OTA update to the `testflight` channel on every push to `main`. This removes the `push` trigger so the workflow only runs via `workflow_dispatch`, making each OTA an explicit, chosen action with a chosen channel and runtime version.

## Test plan

- [ ] Push a commit to `main` and confirm the workflow does not start
- [ ] Run the workflow manually with `channel: testflight` and confirm the update publishes
- [ ] Confirm the iOS and Android build jobs still trigger from a manual run