### PR TITLE
feat(ci): add tracked staging validation

### DIFF
--- a/.github/workflows/build-and-push-bskyweb-docr-staging.yaml
+++ b/.github/workflows/build-and-push-bskyweb-docr-staging.yaml
@@ -11,7 +11,7 @@ on:
         required: true
         type: string
       acceptance_criteria:
-        description: What Rishi should verify on staging
+        description: What behavior to verify on staging
         required: true
         type: string
       ttl_hours:

--- a/.github/workflows/build-and-push-bskyweb-docr-staging.yaml
+++ b/.github/workflows/build-and-push-bskyweb-docr-staging.yaml
@@ -35,12 +35,12 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
         with:
           ref: ${{ inputs.commit_sha }}
 
       - name: Validate staging request
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
         env:
           EXPECTED_SHA: ${{ inputs.commit_sha }}
           PULL_REQUEST: ${{ inputs.pull_request }}
@@ -63,10 +63,10 @@ jobs:
             core.info(`Validated PR #${prNumber} at ${sha} with a ${ttlHours}-hour TTL`)
 
       - name: Setup Docker buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
 
       - name: Install doctl
-        uses: digitalocean/action-doctl@v2
+        uses: digitalocean/action-doctl@3cb3953159719656269e044e0e24ca16dd2a690f # v2
         with:
           token: ${{ secrets.DIGITALOCEAN_ACCESS_TOKEN }}
 
@@ -75,7 +75,7 @@ jobs:
 
       - name: Extract Docker metadata
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@c299e40c65443455700f0fdfc63efafe5b349051 # v5
         with:
           images: |
             registry.digitalocean.com/blacksky/blacksky-community
@@ -91,7 +91,7 @@ jobs:
 
       - name: Build and push Docker image
         id: build-and-push
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@ca052bb54ab0790a636c9b5f226502c73d547a25 # v5
         with:
           context: .
           push: true
@@ -115,7 +115,7 @@ jobs:
 
       - name: Create staging deployment record
         id: deployment
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
         env:
           EXPECTED_SHA: ${{ inputs.commit_sha }}
           PULL_REQUEST: ${{ inputs.pull_request }}
@@ -195,7 +195,7 @@ jobs:
 
       - name: Record final staging status
         if: always() && steps.deployment.outputs.id != ''
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
         env:
           DEPLOYMENT_ID: ${{ steps.deployment.outputs.id }}
           EXPECTED_SHA: ${{ inputs.commit_sha }}

--- a/.github/workflows/build-and-push-bskyweb-docr-staging.yaml
+++ b/.github/workflows/build-and-push-bskyweb-docr-staging.yaml
@@ -1,6 +1,28 @@
 name: build-and-push-bskyweb-docr-staging
 on:
   workflow_dispatch:
+    inputs:
+      pull_request:
+        description: Pull request number to validate
+        required: true
+        type: string
+      commit_sha:
+        description: Exact 40-character PR head SHA to deploy
+        required: true
+        type: string
+      acceptance_criteria:
+        description: What Rishi should verify on staging
+        required: true
+        type: string
+      ttl_hours:
+        description: Hours before this staging claim expires
+        required: true
+        default: "72"
+        type: string
+
+concurrency:
+  group: blacksky-community-client-staging
+  cancel-in-progress: false
 
 jobs:
   bskyweb-container-docr-staging:
@@ -8,10 +30,37 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+      deployments: write
+      pull-requests: read
 
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.commit_sha }}
+
+      - name: Validate staging request
+        uses: actions/github-script@v7
+        env:
+          EXPECTED_SHA: ${{ inputs.commit_sha }}
+          PULL_REQUEST: ${{ inputs.pull_request }}
+          ACCEPTANCE_CRITERIA: ${{ inputs.acceptance_criteria }}
+          TTL_HOURS: ${{ inputs.ttl_hours }}
+        with:
+          script: |
+            const sha = process.env.EXPECTED_SHA.trim().toLowerCase()
+            const prNumber = Number(process.env.PULL_REQUEST)
+            const ttlHours = Number(process.env.TTL_HOURS)
+            if (!/^[0-9a-f]{40}$/.test(sha)) throw new Error('commit_sha must be a full 40-character SHA')
+            if (!Number.isInteger(prNumber) || prNumber <= 0) throw new Error('pull_request must be a positive integer')
+            if (!Number.isFinite(ttlHours) || ttlHours < 1 || ttlHours > 168) throw new Error('ttl_hours must be between 1 and 168')
+            if (core.isDebug()) core.info(`Validating PR #${prNumber} at ${sha}`)
+            const pull = await github.rest.pulls.get({ owner: context.repo.owner, repo: context.repo.repo, pull_number: prNumber })
+            if (pull.data.state !== 'open') throw new Error(`PR #${prNumber} is ${pull.data.state}, not open`)
+            if (pull.data.head.sha.toLowerCase() !== sha) throw new Error(`PR #${prNumber} head is ${pull.data.head.sha}, not ${sha}`)
+            if (process.env.ACCEPTANCE_CRITERIA.trim().length === 0) throw new Error('acceptance_criteria must not be empty')
+
+            core.info(`Validated PR #${prNumber} at ${sha} with a ${ttlHours}-hour TTL`)
 
       - name: Setup Docker buildx
         uses: docker/setup-buildx-action@v3
@@ -63,3 +112,106 @@ jobs:
             EXPO_PUBLIC_GROWTHBOOK_CLIENT_KEY=${{ secrets.EXPO_PUBLIC_GROWTHBOOK_CLIENT_KEY }}
             EXPO_PUBLIC_STRIPE_API_URL=${{ secrets.EXPO_PUBLIC_STRIPE_API_URL }}
             EXPO_PUBLIC_STRIPE_PUBLISHABLE_KEY=${{ secrets.EXPO_PUBLIC_STRIPE_PUBLISHABLE_KEY }}
+
+      - name: Create staging deployment record
+        id: deployment
+        uses: actions/github-script@v7
+        env:
+          EXPECTED_SHA: ${{ inputs.commit_sha }}
+          PULL_REQUEST: ${{ inputs.pull_request }}
+          ACCEPTANCE_CRITERIA: ${{ inputs.acceptance_criteria }}
+          TTL_HOURS: ${{ inputs.ttl_hours }}
+          IMAGE_DIGEST: ${{ steps.build-and-push.outputs.digest }}
+        with:
+          script: |
+            const sha = process.env.EXPECTED_SHA.trim().toLowerCase()
+            const prNumber = Number(process.env.PULL_REQUEST)
+            const expiresAt = new Date(Date.now() + Number(process.env.TTL_HOURS) * 60 * 60 * 1000).toISOString()
+            const created = await github.rest.repos.createDeployment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              ref: sha,
+              auto_merge: false,
+              required_contexts: [],
+              environment: 'client-staging',
+              transient_environment: true,
+              production_environment: false,
+              description: `PR #${prNumber} staging validation`,
+              payload: {
+                schemaVersion: 1,
+                kind: 'client-staging-validation',
+                repository: `${context.repo.owner}/${context.repo.repo}`,
+                pullRequest: prNumber,
+                commitSha: sha,
+                requestedBy: context.actor,
+                expiresAt,
+                acceptanceCriteria: process.env.ACCEPTANCE_CRITERIA.trim(),
+                rollbackImage: `registry.digitalocean.com/blacksky/blacksky-community:staging-${sha}`,
+                imageDigest: process.env.IMAGE_DIGEST,
+              },
+            })
+            core.setOutput('id', String(created.data.id))
+            await github.rest.repos.createDeploymentStatus({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              deployment_id: created.data.id,
+              state: 'in_progress',
+              description: 'Immutable image built; deploying to staging',
+              log_url: `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`,
+              auto_inactive: false,
+            })
+
+      - name: Deploy immutable build to App Platform and verify live SHA
+        env:
+          EXPECTED_SHA: ${{ inputs.commit_sha }}
+          STAGING_URL: https://staging.blacksky.community
+        run: |
+          set -euo pipefail
+          app_id="$(doctl apps list --format ID,Spec.Name --no-header | awk '$2 == "blacksky-community-staging" { print $1 }')"
+          test -n "$app_id"
+          deployment_id="$(doctl apps create-deployment "$app_id" --format ID --no-header)"
+          test -n "$deployment_id"
+
+          phase=""
+          for _ in $(seq 1 60); do
+            phase="$(doctl apps get-deployment "$app_id" "$deployment_id" --format Phase --no-header)"
+            case "$phase" in
+              ACTIVE) break ;;
+              ERROR|CANCELED|SUPERSEDED) echo "App Platform deployment ended in $phase" >&2; exit 1 ;;
+            esac
+            sleep 10
+          done
+          test "$phase" = "ACTIVE"
+
+          for _ in $(seq 1 30); do
+            if curl --fail --silent --show-error --header 'Cache-Control: no-cache' "$STAGING_URL/_release?expected=$EXPECTED_SHA" \
+              | jq --exit-status --arg sha "$EXPECTED_SHA" '.commitSha == $sha' >/dev/null; then
+              exit 0
+            fi
+            sleep 10
+          done
+          echo "Staging never reported expected SHA $EXPECTED_SHA" >&2
+          exit 1
+
+      - name: Record final staging status
+        if: always() && steps.deployment.outputs.id != ''
+        uses: actions/github-script@v7
+        env:
+          DEPLOYMENT_ID: ${{ steps.deployment.outputs.id }}
+          EXPECTED_SHA: ${{ inputs.commit_sha }}
+          JOB_STATUS: ${{ job.status }}
+        with:
+          script: |
+            const success = process.env.JOB_STATUS === 'success'
+            await github.rest.repos.createDeploymentStatus({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              deployment_id: Number(process.env.DEPLOYMENT_ID),
+              state: success ? 'success' : 'failure',
+              description: success
+                ? `Staging serves ${process.env.EXPECTED_SHA.slice(0, 12)}; needs human validation`
+                : `Staging verification failed for ${process.env.EXPECTED_SHA.slice(0, 12)}`,
+              environment_url: 'https://staging.blacksky.community',
+              log_url: `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`,
+              auto_inactive: false,
+            })

--- a/Dockerfile
+++ b/Dockerfile
@@ -99,6 +99,9 @@ FROM golang:1.26-bookworm AS go-build
 
 WORKDIR /usr/src/social-app
 
+ARG EXPO_PUBLIC_RELEASE_VERSION
+ARG EXPO_PUBLIC_BUNDLE_IDENTIFIER
+
 ENV GODEBUG="netdns=go"
 ENV GOOS="linux"
 ENV GOARCH="amd64"
@@ -119,6 +122,7 @@ RUN cd bskyweb/ && \
     -v  \
     -trimpath \
     -tags timetzdata \
+    -ldflags "-X main.releaseCommit=$EXPO_PUBLIC_BUNDLE_IDENTIFIER -X main.releaseVersion=$EXPO_PUBLIC_RELEASE_VERSION" \
     -o /bskyweb \
     ./cmd/bskyweb
 

--- a/bskyweb/cmd/bskyweb/main.go
+++ b/bskyweb/cmd/bskyweb/main.go
@@ -11,6 +11,11 @@ import (
 
 var log = logging.Logger("bskyweb")
 
+var (
+	releaseCommit  = "unknown"
+	releaseVersion = "unknown"
+)
+
 func init() {
 	logging.SetAllLoggers(logging.LevelDebug)
 	//logging.SetAllLoggers(logging.LevelWarn)

--- a/bskyweb/cmd/bskyweb/release_test.go
+++ b/bskyweb/cmd/bskyweb/release_test.go
@@ -1,0 +1,41 @@
+package main
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/labstack/echo/v4"
+)
+
+func TestReleaseIdentity(t *testing.T) {
+	previousCommit, previousVersion := releaseCommit, releaseVersion
+	releaseCommit, releaseVersion = "0123456789abcdef", "1.2.3"
+	t.Cleanup(func() {
+		releaseCommit, releaseVersion = previousCommit, previousVersion
+	})
+
+	e := echo.New()
+	req := httptest.NewRequest(http.MethodGet, "/_release", nil)
+	rec := httptest.NewRecorder()
+	ctx := e.NewContext(req, rec)
+
+	if err := (&Server{}).ReleaseIdentity(ctx); err != nil {
+		t.Fatal(err)
+	}
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d", rec.Code, http.StatusOK)
+	}
+	if got := rec.Header().Get("Cache-Control"); got != "no-store" {
+		t.Fatalf("Cache-Control = %q, want no-store", got)
+	}
+
+	var body map[string]string
+	if err := json.Unmarshal(rec.Body.Bytes(), &body); err != nil {
+		t.Fatal(err)
+	}
+	if body["commitSha"] != releaseCommit || body["version"] != releaseVersion {
+		t.Fatalf("body = %#v", body)
+	}
+}

--- a/bskyweb/cmd/bskyweb/server.go
+++ b/bskyweb/cmd/bskyweb/server.go
@@ -309,6 +309,10 @@ func serve(cctx *cli.Context) error {
 	// PWA manifest (generated dynamically from brand config)
 	e.GET("/manifest.json", server.WebManifest)
 
+	// Immutable build identity used by deployment verification. This intentionally
+	// contains portable release data only; workflow and BB-local state stay elsewhere.
+	e.GET("/_release", server.ReleaseIdentity)
+
 	// OAuth client metadata (generated dynamically from request host)
 	e.GET("/oauth-client-metadata.json", server.OAuthClientMetadata)
 	e.GET("/oauth-client-metadata-native.json", server.OAuthClientMetadataNative)
@@ -482,6 +486,14 @@ func serve(cctx *cli.Context) error {
 	<-quit
 	log.Infof("graceful shutdown complete")
 	return nil
+}
+
+func (srv *Server) ReleaseIdentity(c echo.Context) error {
+	c.Response().Header().Set("Cache-Control", "no-store")
+	return c.JSON(http.StatusOK, map[string]string{
+		"commitSha": releaseCommit,
+		"version":   releaseVersion,
+	})
 }
 
 func newMetricsHTTPServer(address string) (*http.Server, net.Listener, error) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "blacksky.community",
-  "version": "1.127.1",
+  "version": "1.128.0",
   "private": true,
   "packageManager": "pnpm@11.7.0",
   "engines": {


### PR DESCRIPTION
Adds portable GitHub deployment records and exact live release identity verification for manually dispatched client staging builds. Staging requests remain explicit and serialized; metadata contains the PR, SHA, TTL, acceptance criteria, rollback image, and image digest without BB-local identifiers.

Verification:
- `go test ./cmd/bskyweb`
- workflow YAML parse
- repository pre-commit checks
- worktree-local `/_release` preview (registered in BB after PR creation)
