### PR TITLE
fix(android): target API 36

### DIFF
--- a/app.config.js
+++ b/app.config.js
@@ -299,8 +299,8 @@ module.exports = function (_config) {
             },
             android: {
               compileSdkVersion: 36,
-              targetSdkVersion: 35,
-              buildToolsVersion: '35.0.0',
+              targetSdkVersion: 36,
+              buildToolsVersion: '36.0.0',
               buildReactNativeFromSource: IS_PRODUCTION,
             },
           },


### PR DESCRIPTION
## Summary

- target Android 16 / API level 36 for Google Play update compliance
- use Android Build Tools 36.0.0 while retaining the existing compileSdk 36 configuration
- match upstream bluesky-social/social-app commit d9d19c76780691a06603c3f31085d86b3efe35d7

## Why

Starting August 31, 2026, Google Play requires mobile app updates to target API level 36. The app already compiled against API 36, but still targeted API 35.

## Validation

- `pnpm lint`
- `pnpm typecheck`
- production Expo config and clean Android prebuild
- generated manifest confirms `targetSdkVersion="36"`
- Android release `bundleRelease` succeeded, including lint-vital, Kotlin/Java, Hermes, React Native source, and arm64 native compilation
- all 27 arm64 native libraries in the validation AAB have 16 KB-compatible ELF LOAD alignment
- bundle configuration requests 16 KB native-library page alignment
- native fingerprint changed, confirming a fresh Android binary is required

The successful local AAB was validation-only: arm64-only and built with a temporary placeholder Firebase configuration. It must not be submitted to Google Play. A normal production EAS build with production credentials and all ABIs is required after merge.

## Scope

One configuration file; no dependency, Gradle, Expo, React Native, Kotlin, permission, iOS, or build-process changes.