### PR TITLE
feat(chat): add notification enrollment settings

### DIFF
--- a/.github/workflows/bundle-deploy-eas-update.yml
+++ b/.github/workflows/bundle-deploy-eas-update.yml
@@ -2,9 +2,6 @@
 name: Bundle and Deploy EAS Update
 
 on:
-  push:
-    branches:
-      - main
   workflow_dispatch:
     inputs:
       channel:

--- a/docs/chat-notifications-local.md
+++ b/docs/chat-notifications-local.md
@@ -1,0 +1,27 @@
+# Local chat notification testing
+
+Run Courier locally behind a public HTTPS tunnel so the authorization server can fetch its metadata and JWKS and the browser can reach its callback. Use an isolated Courier database. Configure its normal relay environment variables with that public origin.
+
+For browser testing, add these origins to Courier's configuration:
+
+```dotenv
+NODE_ENV=development
+CHAT_RELAY_DEV_ORIGINS=http://127.0.0.1:19007,http://localhost:19007
+CHAT_RELAY_RETURN_ORIGINS=http://127.0.0.1:19007,http://localhost:19007,community.blacksky:/messages/settings
+```
+
+Start the client with the existing web development command:
+
+```sh
+EXPO_PUBLIC_CHAT_RELAY_ENABLED=true \
+EXPO_PUBLIC_CHAT_RELAY_DEV_URL=https://your-courier.example \
+pnpm web --localhost --port 8081
+```
+
+Metro uses port 8081; accept the available web port offered by Expo (19007 in this example). Match Courier’s allowed origins to that web port.
+
+Open `http://127.0.0.1:19007/messages/settings` on the computer running the client. Use `127.0.0.1` consistently: the client's existing loopback sign-in flow returns to that origin. Sign in, enable chat notifications, approve access, and confirm that the browser returns to Chat Settings. Test message/request preferences, reconnect, and disconnect there. A device token is not needed for these controls; receiving actual pushes requires a registered test device and matching provider credentials.
+
+The development override gets a short-lived service-auth token from the signed-in account's PDS for each Courier method. It sends that token directly to the configured Courier origin. It does not send the client's login token, refresh token, or a Courier API key to that origin. The override applies only to the chat relay methods and is ignored when `__DEV__` is false. HTTPS is required except for loopback HTTP endpoints. Other community requests keep their usual PDS proxy route.
+
+Leave the override unset for normal `#chatNotif` service discovery. Courier's development CORS origins are disabled in production. This local path tests authentication, settings, and consent without editing the public AppView DID document; it does not validate public service discovery itself.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "blacksky.community",
-  "version": "1.127.1",
+  "version": "1.128.0",
   "private": true,
   "packageManager": "pnpm@11.7.0",
   "engines": {

--- a/src/Navigation.tsx
+++ b/src/Navigation.tsx
@@ -809,6 +809,7 @@ const LINKING = {
   prefixes: [
     'bsky://',
     'blacksky://',
+    'community.blacksky:',
     'https://bsky.app',
     'https://blacksky.community',
     'https://staging.blacksky.community',

--- a/src/lib/api/__tests__/community.test.ts
+++ b/src/lib/api/__tests__/community.test.ts
@@ -3,6 +3,7 @@ import {type BskyAgent} from '@atproto/api'
 import {
   BLUESKY_FALLBACK_PROXY_HEADER,
   BLUESKY_PROXY_HEADER,
+  CHAT_NOTIF_PROXY_HEADER,
   HOME_PROXY_HEADER,
 } from '#/lib/constants'
 import {communityXrpc} from '../community'
@@ -15,7 +16,7 @@ describe('communityXrpc', () => {
   })
 
   function mockAgent() {
-    const fetchHandler = jest.fn<Promise<Response>, [string, RequestInit]>()
+    const fetchHandler = jest.fn<Promise<Response>, Parameters<typeof fetch>>()
     fetchHandler.mockResolvedValue(new Response('{}'))
     return {agent: {fetchHandler} as unknown as BskyAgent, fetchHandler}
   }
@@ -33,5 +34,154 @@ describe('communityXrpc', () => {
     expect(init.headers['atproto-proxy']).not.toBe(
       BLUESKY_FALLBACK_PROXY_HEADER,
     )
+  })
+
+  it('allows relay XRPCs to target the dedicated chat notification service', async () => {
+    const {agent, fetchHandler} = mockAgent()
+
+    await communityXrpc(agent, 'chat.bsky.notification.getPreferences', {
+      proxyHeader: CHAT_NOTIF_PROXY_HEADER,
+    })
+
+    const init = fetchHandler.mock.calls[0][1] as {
+      headers: Record<string, string>
+    }
+    expect(init.headers['atproto-proxy']).toBe(CHAT_NOTIF_PROXY_HEADER)
+  })
+})
+
+describe('development Courier routing', () => {
+  const originalDev = Object.getOwnPropertyDescriptor(globalThis, '__DEV__')
+  const originalUrl = process.env.EXPO_PUBLIC_CHAT_RELAY_DEV_URL
+  const originalFetch = globalThis.fetch
+  let directFetch: jest.Mock<Promise<Response>, Parameters<typeof fetch>>
+  let getServiceAuth: jest.Mock<
+    Promise<{data: {token: string}}>,
+    [{aud: string; lxm: string; exp: number}, unknown]
+  >
+  let pdsFetch: jest.Mock
+  let agent: BskyAgent
+
+  beforeEach(() => {
+    Object.defineProperty(globalThis, '__DEV__', {
+      value: true,
+      configurable: true,
+    })
+    process.env.EXPO_PUBLIC_CHAT_RELAY_DEV_URL = 'https://courier-test.example'
+    directFetch = jest
+      .fn<Promise<Response>, Parameters<typeof fetch>>()
+      .mockResolvedValue(new Response('{}'))
+    globalThis.fetch = directFetch
+    getServiceAuth = jest
+      .fn<
+        Promise<{data: {token: string}}>,
+        [{aud: string; lxm: string; exp: number}, unknown]
+      >()
+      .mockResolvedValue({data: {token: 'method-bound-service-token'}})
+    pdsFetch = jest.fn().mockResolvedValue(new Response('{}'))
+    agent = {
+      fetchHandler: pdsFetch,
+      com: {atproto: {server: {getServiceAuth}}},
+    } as unknown as BskyAgent
+  })
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch
+    if (originalDev) Object.defineProperty(globalThis, '__DEV__', originalDev)
+    if (originalUrl === undefined)
+      delete process.env.EXPO_PUBLIC_CHAT_RELAY_DEV_URL
+    else process.env.EXPO_PUBLIC_CHAT_RELAY_DEV_URL = originalUrl
+  })
+
+  it('requests exact-method service auth and sends only that token to Courier', async () => {
+    const method = 'chat.bsky.notification.putPreferences'
+    const body = {chat: {push: false}}
+    await communityXrpc(agent, method, {
+      proxyHeader: CHAT_NOTIF_PROXY_HEADER,
+      body,
+    })
+    expect(getServiceAuth).toHaveBeenCalledWith(
+      {
+        aud: 'did:web:api.blacksky.community',
+        lxm: method,
+        exp: expect.any(Number),
+      },
+      expect.objectContaining({headers: {'atproto-proxy': undefined}}),
+    )
+    expect(getServiceAuth.mock.calls[0][0].exp).toBeLessThanOrEqual(
+      Math.floor(Date.now() / 1000) + 60,
+    )
+    expect(directFetch).toHaveBeenCalledWith(
+      `https://courier-test.example/xrpc/${method}`,
+      expect.objectContaining({
+        method: 'POST',
+        body: JSON.stringify(body),
+        credentials: 'omit',
+        redirect: 'error',
+        headers: expect.objectContaining({
+          authorization: 'Bearer method-bound-service-token',
+          'content-type': 'application/json',
+        }),
+      }),
+    )
+    expect(
+      new Headers(directFetch.mock.calls[0][1]?.headers).get('atproto-proxy'),
+    ).toBeNull()
+    expect(pdsFetch).not.toHaveBeenCalled()
+  })
+
+  it('preserves GET query parameters', async () => {
+    await communityXrpc(
+      agent,
+      'community.blacksky.courier.getEnrollmentStatus',
+      {proxyHeader: CHAT_NOTIF_PROXY_HEADER, params: {test: 'a b'}},
+    )
+    expect(directFetch.mock.calls[0][0]).toContain('?test=a+b')
+    expect(directFetch.mock.calls[0][1]?.method).toBe('GET')
+    expect(directFetch.mock.calls[0][1]?.body).toBeUndefined()
+  })
+
+  it('never uses the override in release builds', async () => {
+    Object.defineProperty(globalThis, '__DEV__', {
+      value: false,
+      configurable: true,
+    })
+    await communityXrpc(agent, 'chat.bsky.notification.getPreferences', {
+      proxyHeader: CHAT_NOTIF_PROXY_HEADER,
+    })
+    expect(pdsFetch).toHaveBeenCalledTimes(1)
+    expect(getServiceAuth).not.toHaveBeenCalled()
+    expect(directFetch).not.toHaveBeenCalled()
+  })
+
+  it('leaves other community services on their normal PDS route', async () => {
+    await communityXrpc(agent, 'community.blacksky.feed.getCommunityTimeline')
+    expect(pdsFetch).toHaveBeenCalledTimes(1)
+    expect(getServiceAuth).not.toHaveBeenCalled()
+  })
+
+  it.each([
+    'http://external.example',
+    'https://user:password@courier-test.example',
+    'https://courier-test.example/path',
+  ])('rejects an unsafe endpoint %s before requesting a token', async url => {
+    process.env.EXPO_PUBLIC_CHAT_RELAY_DEV_URL = url
+    await expect(
+      communityXrpc(agent, 'chat.bsky.notification.getPreferences', {
+        proxyHeader: CHAT_NOTIF_PROXY_HEADER,
+      }),
+    ).rejects.toThrow()
+    expect(getServiceAuth).not.toHaveBeenCalled()
+    expect(directFetch).not.toHaveBeenCalled()
+  })
+
+  it('does not send a request if PDS authorization fails', async () => {
+    getServiceAuth.mockRejectedValueOnce(new Error('No session'))
+    await expect(
+      communityXrpc(agent, 'chat.bsky.notification.getPreferences', {
+        proxyHeader: CHAT_NOTIF_PROXY_HEADER,
+      }),
+    ).rejects.toThrow('No session')
+    expect(directFetch).not.toHaveBeenCalled()
   })
 })

--- a/src/lib/api/community.ts
+++ b/src/lib/api/community.ts
@@ -1,15 +1,43 @@
 import {type BskyAgent} from '@atproto/api'
 
-import {HOME_PROXY_HEADER} from '#/lib/constants'
+import {
+  CHAT_NOTIF_PROXY_HEADER,
+  HOME_PROXY_HEADER,
+  PUBLIC_APPVIEW_DID,
+} from '#/lib/constants'
+import {type ProxyHeaderValue} from '#/state/session/agent'
+
+const CHAT_RELAY_METHODS = new Set([
+  'community.blacksky.courier.startEnrollment',
+  'community.blacksky.courier.getEnrollmentStatus',
+  'community.blacksky.courier.disconnect',
+  'chat.bsky.notification.getPreferences',
+  'chat.bsky.notification.putPreferences',
+])
+
+function developmentCourierOrigin(): string | undefined {
+  if (!__DEV__ || !process.env.EXPO_PUBLIC_CHAT_RELAY_DEV_URL) return undefined
+  const url = new URL(process.env.EXPO_PUBLIC_CHAT_RELAY_DEV_URL)
+  const loopback = ['localhost', '127.0.0.1', '[::1]'].includes(url.hostname)
+  if (
+    (url.protocol !== 'https:' && !(url.protocol === 'http:' && loopback)) ||
+    url.username ||
+    url.password ||
+    url.search ||
+    url.hash ||
+    url.pathname !== '/'
+  ) {
+    throw new Error(
+      'The development Courier URL must be an HTTPS origin or local HTTP origin',
+    )
+  }
+  return url.origin
+}
 
 /**
- * Make an XRPC call to a community.blacksky.feed.* endpoint.
+ * Make an XRPC call to a community endpoint.
  *
- * Calls through the PDS using the agent's session auth and atproto-proxy
- * header. The PDS validates the user's credentials, creates a service auth
- * JWT signed by the user's keypair, and forwards the request to the appview.
- *
- * Pinned: community.blacksky.* endpoints only exist on the home appview.
+ * Calls through the account's PDS with the supplied proxy header.
  */
 export async function communityXrpc(
   agent: BskyAgent,
@@ -17,6 +45,7 @@ export async function communityXrpc(
   opts?: {
     params?: Record<string, string>
     body?: unknown
+    proxyHeader?: ProxyHeaderValue
   },
 ): Promise<Response> {
   const qs = opts?.params
@@ -24,8 +53,48 @@ export async function communityXrpc(
     : ''
   const path = `/xrpc/${method}${qs}`
 
+  const developmentOrigin =
+    opts?.proxyHeader === CHAT_NOTIF_PROXY_HEADER
+      ? developmentCourierOrigin()
+      : undefined
+  if (developmentOrigin) {
+    if (!CHAT_RELAY_METHODS.has(method))
+      throw new Error('Unsupported development Courier method')
+    const controller = new AbortController()
+    const timer = setTimeout(() => controller.abort(), 30_000)
+    try {
+      const {data} = await agent.com.atproto.server.getServiceAuth(
+        {
+          aud: PUBLIC_APPVIEW_DID,
+          lxm: method,
+          exp: Math.floor(Date.now() / 1000) + 60,
+        },
+        {signal: controller.signal, headers: {'atproto-proxy': undefined}},
+      )
+      if (!data.token)
+        throw new Error('Could not authorize the development Courier request')
+      return await fetch(`${developmentOrigin}${path}`, {
+        method: opts?.body !== undefined ? 'POST' : 'GET',
+        headers: {
+          authorization: `Bearer ${data.token}`,
+          accept: 'application/json',
+          'ngrok-skip-browser-warning': '1',
+          ...(opts?.body !== undefined
+            ? {'content-type': 'application/json'}
+            : {}),
+        },
+        body: opts?.body !== undefined ? JSON.stringify(opts.body) : undefined,
+        credentials: 'omit',
+        redirect: 'error',
+        signal: controller.signal,
+      })
+    } finally {
+      clearTimeout(timer)
+    }
+  }
+
   const headers: Record<string, string> = {
-    'atproto-proxy': HOME_PROXY_HEADER,
+    'atproto-proxy': opts?.proxyHeader ?? HOME_PROXY_HEADER,
   }
   const init: RequestInit = {
     method: opts?.body ? 'POST' : 'GET',

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -215,6 +215,11 @@ export const PUBLIC_APPVIEW = 'https://api.blacksky.community'
 export const PUBLIC_APPVIEW_DID = 'did:web:api.blacksky.community'
 export const PUBLIC_STAGING_APPVIEW_DID = 'did:web:api.staging.bsky.dev'
 
+export const CHAT_RELAY_ENABLED =
+  process.env.EXPO_PUBLIC_CHAT_RELAY_ENABLED === 'true'
+export const CHAT_NOTIF_PROXY_HEADER =
+  `${PUBLIC_APPVIEW_DID}#chatNotif` as ProxyHeaderValue
+
 export const APPVIEW_STATUS_URL = `${PUBLIC_APPVIEW}/status/indexer`
 
 export const BLUESKY_FALLBACK_PROXY_DID = 'did:web:api.bsky.app'

--- a/src/lib/hooks/useNotificationHandler.ts
+++ b/src/lib/hooks/useNotificationHandler.ts
@@ -58,13 +58,13 @@ export type NotificationPayload =
   | {
       reason: 'chat-message'
       convoId: string
-      messageId: string
+      messageId?: string
       recipientDid: string
     }
   | {
       reason: 'chat-reaction'
       convoId: string
-      messageId: string
+      messageId?: string
       recipientDid: string
     }
   | {

--- a/src/locale/locales/en/messages.po
+++ b/src/locale/locales/en/messages.po
@@ -923,6 +923,10 @@ msgstr ""
 msgid "A selected recipient is not followed by the sender."
 msgstr "A selected recipient is not followed by the sender."
 
+#: src/screens/Messages/Settings.tsx:374
+msgid "A sign-in page will ask you to let Blacksky check your chats, then bring you back here. Alerts may take a few minutes to arrive."
+msgstr "A sign-in page will ask you to let Blacksky check your chats, then bring you back here. Alerts may take a few minutes to arrive."
+
 #: src/Navigation.tsx:492
 #: src/screens/Settings/AboutSettings.tsx:76
 #: src/screens/Settings/Settings.tsx:257
@@ -1417,13 +1421,13 @@ msgstr ""
 msgid "Allow anyone to reply"
 msgstr ""
 
-#: src/screens/Messages/Settings.tsx:130
-#: src/screens/Messages/Settings.tsx:145
+#: src/screens/Messages/Settings.tsx:140
+#: src/screens/Messages/Settings.tsx:155
 msgid "Allow direct messages from"
 msgstr "Allow direct messages from"
 
-#: src/screens/Messages/Settings.tsx:176
-#: src/screens/Messages/Settings.tsx:198
+#: src/screens/Messages/Settings.tsx:186
+#: src/screens/Messages/Settings.tsx:208
 msgid "Allow group chat invites from"
 msgstr "Allow group chat invites from"
 
@@ -2523,6 +2527,18 @@ msgstr ""
 msgid "Chat not found."
 msgstr "Chat not found."
 
+#: src/screens/Messages/Settings.tsx:348
+msgid "Chat notifications"
+msgstr "Chat notifications"
+
+#: src/screens/Messages/Settings.tsx:364
+msgid "Chat notifications are disabled."
+msgstr "Chat notifications are disabled."
+
+#: src/screens/Messages/Settings.tsx:362
+msgid "Chat notifications need to be reconnected."
+msgstr "Chat notifications need to be reconnected."
+
 #: src/components/moderation/BlockDialog.tsx:293
 msgid "Chat owners cannot leave a group chat."
 msgstr "Chat owners cannot leave a group chat."
@@ -2536,8 +2552,13 @@ msgid "Chat request inbox"
 msgstr ""
 
 #: src/screens/Messages/Inbox.tsx:94
+#: src/screens/Messages/Settings.tsx:457
 msgid "Chat requests"
 msgstr ""
+
+#: src/screens/Messages/Settings.tsx:472
+msgid "Chat requests from"
+msgstr "Chat requests from"
 
 #: src/components/dms/ConvoMenu.tsx:88
 #: src/Navigation.tsx:533
@@ -2546,7 +2567,7 @@ msgstr ""
 msgid "Chat settings"
 msgstr ""
 
-#: src/screens/Messages/Settings.tsx:121
+#: src/screens/Messages/Settings.tsx:131
 msgid "Chat Settings"
 msgstr ""
 
@@ -2948,6 +2969,10 @@ msgstr "Confirm with your account password"
 msgid "Confirmation code"
 msgstr ""
 
+#: src/screens/Messages/Settings.tsx:356
+msgid "Connected. Blacksky checks your Bluesky chats while this app is closed. Alerts say “New message” and may take a few minutes to arrive."
+msgstr "Connected. Blacksky checks your Bluesky chats while this app is closed. Alerts say “New message” and may take a few minutes to arrive."
+
 #: src/screens/Signup/index.tsx:284
 #: src/screens/Signup/index.tsx:287
 msgid "Contact support"
@@ -3205,6 +3230,10 @@ msgstr ""
 msgid "Could not capture QR code"
 msgstr "Could not capture QR code"
 
+#: src/screens/Messages/Settings.tsx:323
+msgid "Could not connect chat notifications"
+msgstr "Could not connect chat notifications"
+
 #: src/view/com/feeds/MissingFeed.tsx:42
 msgid "Could not connect to custom feed"
 msgstr ""
@@ -3216,6 +3245,10 @@ msgstr ""
 #: src/features/inviteFriends/InviteFriendsDialogInner.tsx:121
 msgid "Could not copy – please try again"
 msgstr "Could not copy – please try again"
+
+#: src/screens/Messages/Settings.tsx:329
+msgid "Could not disconnect chat notifications"
+msgstr "Could not disconnect chat notifications"
 
 #: src/features/inviteFriends/InviteFriendsDialogInner.tsx:75
 msgid "Could not download – please try again"
@@ -3249,6 +3282,10 @@ msgstr ""
 #: src/components/moderation/BlockDialog.tsx:285
 msgid "Could not leave chat."
 msgstr "Could not leave chat."
+
+#: src/screens/Messages/Settings.tsx:354
+msgid "Could not load chat notification settings."
+msgstr "Could not load chat notification settings."
 
 #: src/screens/Profile/ProfileFeed/index.tsx:73
 msgid "Could not load feed"
@@ -3284,6 +3321,10 @@ msgstr ""
 #: src/features/inviteFriends/InviteFriendsDialogInner.tsx:61
 msgid "Could not share – please try again"
 msgstr "Could not share – please try again"
+
+#: src/screens/Messages/Settings.tsx:337
+msgid "Could not update chat notification settings"
+msgstr "Could not update chat notification settings"
 
 #: src/state/queries/notifications/settings.ts:55
 msgid "Could not update notification settings"
@@ -3804,6 +3845,14 @@ msgstr ""
 msgid "Discard post?"
 msgstr ""
 
+#: src/screens/Messages/Settings.tsx:507
+msgid "Disconnect"
+msgstr "Disconnect"
+
+#: src/screens/Messages/Settings.tsx:501
+msgid "Disconnect chat notifications"
+msgstr "Disconnect chat notifications"
+
 #: src/screens/Profile/components/GermButton.tsx:262
 #: src/screens/Profile/components/GermButton.tsx:269
 msgid "Disconnect Germ DM"
@@ -4248,6 +4297,7 @@ msgstr "Embedding"
 
 #: src/components/dialogs/EmailDialog/screens/Manage2FA/Enable.tsx:101
 #: src/components/dialogs/EmailDialog/screens/Manage2FA/Enable.tsx:108
+#: src/screens/Messages/Settings.tsx:406
 #: src/screens/Settings/components/Email2FAToggle.tsx:31
 msgid "Enable"
 msgstr ""
@@ -4264,6 +4314,14 @@ msgstr ""
 #: src/components/Post/Embed/VideoEmbed/VideoEmbedInner/web-controls/VideoControls.tsx:415
 msgid "Enable captions"
 msgstr "Enable captions"
+
+#: src/screens/Messages/Settings.tsx:396
+msgid "Enable chat notifications"
+msgstr "Enable chat notifications"
+
+#: src/screens/Messages/Settings.tsx:366
+msgid "Enable chat notifications to receive alerts when a Bluesky chat arrives while the app is closed."
+msgstr "Enable chat notifications to receive alerts when a Bluesky chat arrives while the app is closed."
 
 #: src/components/dialogs/EmailDialog/screens/Manage2FA/Enable.tsx:91
 msgid "Enable email 2FA"
@@ -4444,17 +4502,21 @@ msgstr ""
 msgid "Everybody can reply to this post."
 msgstr ""
 
+#: src/screens/Messages/Settings.tsx:436
+#: src/screens/Messages/Settings.tsx:439
+#: src/screens/Messages/Settings.tsx:480
+#: src/screens/Messages/Settings.tsx:483
 #: src/screens/Settings/NotificationSettings/components/PreferenceControls.tsx:171
 #: src/screens/Settings/NotificationSettings/components/PreferenceControls.tsx:174
 msgid "Everyone"
 msgstr ""
 
-#: src/screens/Messages/Settings.tsx:67
+#: src/screens/Messages/Settings.tsx:77
 msgctxt "allow group chat invites from"
 msgid "Everyone"
 msgstr "Everyone"
 
-#: src/screens/Messages/Settings.tsx:52
+#: src/screens/Messages/Settings.tsx:62
 msgctxt "allow messages from"
 msgid "Everyone"
 msgstr "Everyone"
@@ -4549,8 +4611,8 @@ msgstr ""
 msgid "Explore the app"
 msgstr ""
 
-#: src/screens/Messages/Settings.tsx:254
-#: src/screens/Messages/Settings.tsx:264
+#: src/screens/Messages/Settings.tsx:265
+#: src/screens/Messages/Settings.tsx:275
 #: src/screens/Settings/components/ExportCarDialog.tsx:129
 msgid "Export my chat data"
 msgstr "Export my chat data"
@@ -4875,7 +4937,7 @@ msgstr ""
 msgid "Failed to update notification declaration"
 msgstr ""
 
-#: src/screens/Messages/Settings.tsx:84
+#: src/screens/Messages/Settings.tsx:94
 msgid "Failed to update settings"
 msgstr ""
 
@@ -5621,7 +5683,7 @@ msgctxt "toast"
 msgid "Group chat unmuted"
 msgstr "Group chat unmuted"
 
-#: src/screens/Messages/Settings.tsx:186
+#: src/screens/Messages/Settings.tsx:196
 msgid "Group chats are only available to users 18 and over."
 msgstr "Group chats are only available to users 18 and over."
 
@@ -6777,6 +6839,10 @@ msgstr ""
 msgid "Load new posts"
 msgstr ""
 
+#: src/screens/Messages/Settings.tsx:352
+msgid "Loading chat notification settings..."
+msgstr "Loading chat notification settings..."
+
 #: src/screens/Messages/components/MessageComposer.tsx:245
 #: src/screens/Messages/components/MessageInput.tsx:258
 #: src/screens/Messages/components/MessageInput.web.tsx:228
@@ -7045,8 +7111,13 @@ msgid "Message options"
 msgstr ""
 
 #: src/Navigation.tsx:788
+#: src/screens/Messages/Settings.tsx:413
 msgid "Messages"
 msgstr ""
+
+#: src/screens/Messages/Settings.tsx:428
+msgid "Messages from"
+msgstr "Messages from"
 
 #: src/components/dms/MessageItem.tsx:715
 msgid "Messages from this person are hidden while they are blocking you."
@@ -7609,12 +7680,12 @@ msgstr ""
 msgid "No notifications yet!"
 msgstr ""
 
-#: src/screens/Messages/Settings.tsx:78
+#: src/screens/Messages/Settings.tsx:88
 msgctxt "allow group chat invites from"
 msgid "No one"
 msgstr "No one"
 
-#: src/screens/Messages/Settings.tsx:60
+#: src/screens/Messages/Settings.tsx:70
 msgctxt "allow messages from"
 msgid "No one"
 msgstr ""
@@ -7792,8 +7863,8 @@ msgstr ""
 msgid "Notification settings"
 msgstr ""
 
-#: src/screens/Messages/Settings.tsx:231
-#: src/screens/Messages/Settings.tsx:244
+#: src/screens/Messages/Settings.tsx:241
+#: src/screens/Messages/Settings.tsx:254
 msgid "Notification sounds"
 msgstr ""
 
@@ -8403,12 +8474,12 @@ msgstr ""
 msgid "People I follow"
 msgstr ""
 
-#: src/screens/Messages/Settings.tsx:71
+#: src/screens/Messages/Settings.tsx:81
 msgctxt "allow group chat invites from"
 msgid "People I follow"
 msgstr "People I follow"
 
-#: src/screens/Messages/Settings.tsx:56
+#: src/screens/Messages/Settings.tsx:66
 msgctxt "allow messages from"
 msgid "People I follow"
 msgstr "People I follow"
@@ -8422,6 +8493,10 @@ msgid "People I follow can request to join"
 msgstr "People I follow can request to join"
 
 #: src/components/dialogs/PostInteractionSettingsDialog.tsx:510
+#: src/screens/Messages/Settings.tsx:446
+#: src/screens/Messages/Settings.tsx:450
+#: src/screens/Messages/Settings.tsx:490
+#: src/screens/Messages/Settings.tsx:494
 msgid "People you follow"
 msgstr ""
 
@@ -8981,9 +9056,19 @@ msgstr ""
 msgid "Push"
 msgstr ""
 
+#: src/screens/Messages/Settings.tsx:422
+#: src/screens/Messages/Settings.tsx:466
 #: src/screens/Settings/NotificationSettings/components/PreferenceControls.tsx:134
 msgid "Push notifications"
 msgstr ""
+
+#: src/screens/Messages/Settings.tsx:460
+msgid "Push notifications for chat requests"
+msgstr "Push notifications for chat requests"
+
+#: src/screens/Messages/Settings.tsx:416
+msgid "Push notifications for messages"
+msgstr "Push notifications for messages"
 
 #: src/screens/Settings/NotificationSettings/index.tsx:373
 msgid "Push, everyone"
@@ -9148,8 +9233,13 @@ msgid "Recommended"
 msgstr ""
 
 #: src/screens/Messages/components/MessageListError.tsx:19
+#: src/screens/Messages/Settings.tsx:404
 msgid "Reconnect"
 msgstr ""
+
+#: src/screens/Messages/Settings.tsx:395
+msgid "Reconnect chat notifications"
+msgstr "Reconnect chat notifications"
 
 #. Reject a chat request, this opens a menu with options
 #: src/screens/Messages/components/RequestButtons.tsx:136
@@ -9772,6 +9862,7 @@ msgstr ""
 #: src/screens/Messages/components/MessageListError.tsx:24
 #: src/screens/Messages/Inbox.tsx:208
 #: src/screens/Messages/JoinRequests.tsx:351
+#: src/screens/Messages/Settings.tsx:388
 #: src/screens/Onboarding/StepSuggestedAccounts/index.tsx:268
 #: src/screens/Onboarding/StepSuggestedAccounts/index.tsx:271
 #: src/screens/Onboarding/StepSuggestedStarterpacks/index.tsx:104
@@ -9784,6 +9875,10 @@ msgstr ""
 #: src/view/screens/Storybook/Admonitions.tsx:64
 msgid "Retry"
 msgstr ""
+
+#: src/screens/Messages/Settings.tsx:382
+msgid "Retry chat notification settings"
+msgstr "Retry chat notification settings"
 
 #: src/components/moderation/ReportDialog/index.tsx:294
 #: src/view/screens/Storybook/Admonitions.tsx:61
@@ -13575,8 +13670,8 @@ msgstr ""
 msgid "You can choose whether chat notifications have sound in the chat settings within the app"
 msgstr ""
 
-#: src/screens/Messages/Settings.tsx:139
-#: src/screens/Messages/Settings.tsx:190
+#: src/screens/Messages/Settings.tsx:149
+#: src/screens/Messages/Settings.tsx:200
 msgid "You can continue ongoing conversations regardless of which setting you choose."
 msgstr ""
 

--- a/src/screens/Messages/Settings.tsx
+++ b/src/screens/Messages/Settings.tsx
@@ -1,14 +1,24 @@
-import {useCallback} from 'react'
+import {useCallback, useEffect} from 'react'
 import {View} from 'react-native'
 import {Trans, useLingui} from '@lingui/react/macro'
+import {useIsFocused} from '@react-navigation/native'
 import {type NativeStackScreenProps} from '@react-navigation/native-stack'
 
+import {useAppState} from '#/lib/appState'
+import {CHAT_RELAY_ENABLED} from '#/lib/constants'
 import {type CommonNavigatorParams} from '#/lib/routes/types'
 import {useUpdateActorDeclaration} from '#/state/queries/messages/actor-declaration'
+import {
+  useChatRelayDisconnectMutation,
+  useChatRelayEnrollmentMutation,
+  useChatRelayPreferencesMutation,
+  useChatRelayStatusQuery,
+} from '#/state/queries/notifications/chat-relay'
 import {useProfileQuery} from '#/state/queries/profile'
 import {useSession} from '#/state/session'
 import {ExportCarDialog} from '#/screens/Settings/components/ExportCarDialog'
 import {atoms as a, useTheme} from '#/alf'
+import {Button, ButtonText} from '#/components/Button'
 import * as Dialog from '#/components/Dialog'
 import {Divider} from '#/components/Divider'
 import {resolveAllowGroupInvites} from '#/components/dms/util'
@@ -249,6 +259,7 @@ export function MessagesSettingsScreenInner({}: Props) {
               <Divider style={{marginVertical: 10}} />
             </>
           )}
+          {CHAT_RELAY_ENABLED && <ChatRelaySettings />}
           <View style={[a.px_xl]}>
             <Toggle.Item
               label={l`Export my chat data`}
@@ -271,5 +282,239 @@ export function MessagesSettingsScreenInner({}: Props) {
       </Layout.Content>
       <ExportCarDialog control={exportCarControl} />
     </Layout.Screen>
+  )
+}
+
+function ChatRelaySettings() {
+  const t = useTheme()
+  const {t: l} = useLingui()
+  const {currentAccount} = useSession()
+  const {
+    data: relay,
+    error: relayError,
+    isError,
+    isFetching,
+    isPending,
+    refetch,
+  } = useChatRelayStatusQuery()
+  const enrollment = useChatRelayEnrollmentMutation()
+  const disconnect = useChatRelayDisconnectMutation()
+  const update = useChatRelayPreferencesMutation()
+  const isFocused = useIsFocused()
+  const appState = useAppState()
+
+  useEffect(() => {
+    if (isFocused && appState === 'active') {
+      void refetch().catch(() => undefined)
+    }
+  }, [appState, isFocused, refetch])
+
+  const busy = enrollment.isPending || disconnect.isPending || update.isPending
+  const retry = () => {
+    void refetch().catch(() => undefined)
+  }
+
+  const preferences = relay?.preferences
+  const connected = relay?.status === 'active' && !!preferences
+  const enroll = () => {
+    if (!currentAccount?.did || !currentAccount.handle) return
+    void enrollment
+      .mutateAsync({did: currentAccount.did, handle: currentAccount.handle})
+      .catch(() => {
+        Toast.show(l`Could not connect chat notifications`, {type: 'error'})
+      })
+  }
+  const disconnectRelay = () => {
+    if (!currentAccount?.did) return
+    void disconnect.mutateAsync({did: currentAccount.did}).catch(() => {
+      Toast.show(l`Could not disconnect chat notifications`, {type: 'error'})
+    })
+  }
+  const updatePreferences = (
+    patch: Parameters<typeof update.mutate>[0]['patch'],
+  ) => {
+    if (!currentAccount?.did) return
+    void update.mutateAsync({did: currentAccount.did, patch}).catch(() => {
+      Toast.show(l`Could not update chat notification settings`, {
+        type: 'error',
+      })
+    })
+  }
+
+  return (
+    <>
+      <Divider style={{marginVertical: 10}} />
+      <View style={[a.px_xl, a.gap_sm]}>
+        <Text style={[a.text_md, a.font_semi_bold, t.atoms.text]}>
+          <Trans>Chat notifications</Trans>
+        </Text>
+        <Text style={[a.text_sm, a.leading_snug, t.atoms.text_contrast_high]}>
+          {isPending ? (
+            <Trans>Loading chat notification settings...</Trans>
+          ) : isError ? (
+            __DEV__ && relayError instanceof Error ? (
+              relayError.message
+            ) : (
+              <Trans>Could not load chat notification settings.</Trans>
+            )
+          ) : connected ? (
+            <Trans>
+              Connected. Blacksky checks your Bluesky chats while this app is
+              closed. Alerts say “New message” and may take a few minutes to
+              arrive.
+            </Trans>
+          ) : relay?.status === 'reauth_required' ? (
+            <Trans>Chat notifications need to be reconnected.</Trans>
+          ) : relay?.status === 'disconnected' ? (
+            <Trans>Chat notifications are disabled.</Trans>
+          ) : (
+            <Trans>
+              Enable chat notifications to receive alerts when a Bluesky chat
+              arrives while the app is closed.
+            </Trans>
+          )}
+        </Text>
+        {!isPending && !isError && !connected ? (
+          <Text style={[a.text_sm, a.leading_snug, t.atoms.text_contrast_high]}>
+            <Trans>
+              A sign-in page will ask you to let Blacksky check your chats, then
+              bring you back here. Alerts may take a few minutes to arrive.
+            </Trans>
+          </Text>
+        ) : null}
+        {isPending ? null : isError ? (
+          <Button
+            label={l`Retry chat notification settings`}
+            color="secondary"
+            variant="outline"
+            onPress={retry}
+            disabled={isFetching || busy}>
+            <ButtonText>
+              <Trans>Retry</Trans>
+            </ButtonText>
+          </Button>
+        ) : !connected ? (
+          <Button
+            label={
+              relay?.status === 'reauth_required'
+                ? l`Reconnect chat notifications`
+                : l`Enable chat notifications`
+            }
+            color="primary"
+            variant="solid"
+            onPress={enroll}
+            disabled={busy}>
+            <ButtonText>
+              {relay?.status === 'reauth_required' ? (
+                <Trans>Reconnect</Trans>
+              ) : (
+                <Trans>Enable</Trans>
+              )}
+            </ButtonText>
+          </Button>
+        ) : (
+          <>
+            <Text style={[a.text_sm, a.font_semi_bold, t.atoms.text]}>
+              <Trans>Messages</Trans>
+            </Text>
+            <Toggle.Item
+              label={l`Push notifications for messages`}
+              name="relay-chat-push"
+              value={preferences.chat.push}
+              disabled={busy}
+              onChange={push => updatePreferences({chat: {push}})}>
+              <Toggle.LabelText>
+                <Trans>Push notifications</Trans>
+              </Toggle.LabelText>
+              <Toggle.Switch />
+            </Toggle.Item>
+            <Toggle.Group
+              type="radio"
+              label={l`Messages from`}
+              values={[preferences.chat.include]}
+              disabled={busy}
+              onChange={([include]) => {
+                if (include === 'all' || include === 'follows') {
+                  updatePreferences({chat: {include}})
+                }
+              }}>
+              <Toggle.Item highlightRow label={l`Everyone`} name="all">
+                {({selected}) => (
+                  <Toggle.RadioWithLabel
+                    label={l`Everyone`}
+                    selected={selected}
+                  />
+                )}
+              </Toggle.Item>
+              <Toggle.Item
+                highlightRow
+                label={l`People you follow`}
+                name="follows">
+                {({selected}) => (
+                  <Toggle.RadioWithLabel
+                    label={l`People you follow`}
+                    selected={selected}
+                  />
+                )}
+              </Toggle.Item>
+            </Toggle.Group>
+            <Text style={[a.text_sm, a.font_semi_bold, t.atoms.text]}>
+              <Trans>Chat requests</Trans>
+            </Text>
+            <Toggle.Item
+              label={l`Push notifications for chat requests`}
+              name="relay-chat-request-push"
+              value={preferences.chatRequest.push}
+              disabled={busy}
+              onChange={push => updatePreferences({chatRequest: {push}})}>
+              <Toggle.LabelText>
+                <Trans>Push notifications</Trans>
+              </Toggle.LabelText>
+              <Toggle.Switch />
+            </Toggle.Item>
+            <Toggle.Group
+              type="radio"
+              label={l`Chat requests from`}
+              values={[preferences.chatRequest.include]}
+              disabled={busy}
+              onChange={([include]) => {
+                if (include === 'all' || include === 'follows') {
+                  updatePreferences({chatRequest: {include}})
+                }
+              }}>
+              <Toggle.Item highlightRow label={l`Everyone`} name="all">
+                {({selected}) => (
+                  <Toggle.RadioWithLabel
+                    label={l`Everyone`}
+                    selected={selected}
+                  />
+                )}
+              </Toggle.Item>
+              <Toggle.Item
+                highlightRow
+                label={l`People you follow`}
+                name="follows">
+                {({selected}) => (
+                  <Toggle.RadioWithLabel
+                    label={l`People you follow`}
+                    selected={selected}
+                  />
+                )}
+              </Toggle.Item>
+            </Toggle.Group>
+            <Button
+              label={l`Disconnect chat notifications`}
+              color="secondary"
+              variant="outline"
+              onPress={disconnectRelay}
+              disabled={busy}>
+              <ButtonText>
+                <Trans>Disconnect</Trans>
+              </ButtonText>
+            </Button>
+          </>
+        )}
+      </View>
+    </>
   )
 }

--- a/src/state/queries/notifications/chat-relay.test.tsx
+++ b/src/state/queries/notifications/chat-relay.test.tsx
@@ -1,0 +1,140 @@
+import {type ReactNode} from 'react'
+import {QueryClient, QueryClientProvider} from '@tanstack/react-query'
+import {act, renderHook} from '@testing-library/react-native'
+
+import {communityXrpc} from '#/lib/api/community'
+import {useAgent, useSession} from '#/state/session'
+import {
+  CHAT_RELAY_REDIRECT_URI,
+  chatRelayQueryKey,
+  chatRelayReturnTo,
+  useChatRelayPreferencesMutation,
+} from './chat-relay'
+
+jest.mock('#/env', () => ({IS_NATIVE: false}))
+jest.mock('#/lib/api/community', () => ({communityXrpc: jest.fn()}))
+jest.mock('#/state/session', () => ({
+  useAgent: jest.fn(),
+  useSession: jest.fn(),
+}))
+
+jest.mock('#/lib/constants', () => ({
+  ...jest.requireActual('#/lib/constants'),
+  CHAT_RELAY_ENABLED: true,
+}))
+
+describe('chat relay mutations', () => {
+  it('uses the settings page for native OAuth completion', () => {
+    expect(CHAT_RELAY_REDIRECT_URI).toBe(
+      'community.blacksky:/messages/settings',
+    )
+    expect(chatRelayReturnTo()).toBeUndefined()
+  })
+
+  it.each(['https://blacksky.community', 'https://staging.blacksky.community'])(
+    'uses the browser settings page for OAuth completion from %s',
+    origin => {
+      const previousLocation = window.location
+      Object.defineProperty(window, 'location', {
+        configurable: true,
+        value: {origin},
+      })
+      try {
+        expect(chatRelayReturnTo()).toBe(`${origin}/messages/settings`)
+      } finally {
+        Object.defineProperty(window, 'location', {
+          configurable: true,
+          value: previousLocation,
+        })
+      }
+    },
+  )
+
+  it('keeps the initiating account when the active account changes mid-request', async () => {
+    const accountA = {did: 'did:plc:account-a', handle: 'a.example'}
+    const accountB = {did: 'did:plc:account-b', handle: 'b.example'}
+    let activeAccount = accountA
+    const agent = {}
+    jest.mocked(useAgent).mockReturnValue(agent as ReturnType<typeof useAgent>)
+    jest.mocked(useSession).mockImplementation(
+      () =>
+        ({
+          currentAccount: activeAccount,
+        }) as ReturnType<typeof useSession>,
+    )
+
+    let resolveResponse!: (value: Response) => void
+    const response = new Promise<Response>(resolve => {
+      resolveResponse = resolve
+    })
+    jest.mocked(communityXrpc).mockImplementationOnce(() => response)
+
+    const client = new QueryClient({
+      defaultOptions: {
+        queries: {retry: false, gcTime: Infinity},
+        mutations: {retry: false, gcTime: 0},
+      },
+    })
+    const initialA = {
+      did: accountA.did,
+      status: 'active' as const,
+      preferences: {
+        chat: {push: true, include: 'all' as const},
+        chatRequest: {push: true, include: 'all' as const},
+      },
+    }
+    const initialB = {...initialA, did: accountB.did}
+    client.setQueryData(chatRelayQueryKey(accountA.did), initialA)
+    client.setQueryData(chatRelayQueryKey(accountB.did), initialB)
+
+    const wrapper = ({children}: {children: ReactNode}) => (
+      <QueryClientProvider client={client}>{children}</QueryClientProvider>
+    )
+    const {result, rerender, unmount} = renderHook(
+      () => ({
+        account: jest.mocked(useSession)(),
+        mutation: useChatRelayPreferencesMutation(),
+      }),
+      {wrapper},
+    )
+
+    let pending!: Promise<unknown>
+    act(() => {
+      pending = result.current.mutation.mutateAsync({
+        did: result.current.account.currentAccount!.did,
+        patch: {chat: {push: false}},
+      })
+    })
+    activeAccount = accountB
+    act(() => {
+      rerender(undefined)
+    })
+
+    resolveResponse(
+      new Response(
+        JSON.stringify({
+          preferences: {
+            chat: {push: false, include: 'all'},
+            chatRequest: {push: true, include: 'all'},
+          },
+        }),
+      ),
+    )
+    await act(async () => {
+      await pending
+    })
+
+    expect(client.getQueryData(chatRelayQueryKey(accountA.did))).toEqual({
+      ...initialA,
+      preferences: {
+        chat: {push: false, include: 'all'},
+        chatRequest: {push: true, include: 'all'},
+      },
+    })
+    expect(client.getQueryData(chatRelayQueryKey(accountB.did))).toEqual(
+      initialB,
+    )
+    unmount()
+    client.clear()
+  })
+})

--- a/src/state/queries/notifications/chat-relay.ts
+++ b/src/state/queries/notifications/chat-relay.ts
@@ -1,0 +1,205 @@
+import {openAuthSessionAsync} from 'expo-web-browser'
+import {useMutation, useQuery, useQueryClient} from '@tanstack/react-query'
+
+import {communityXrpc} from '#/lib/api/community'
+import {CHAT_NOTIF_PROXY_HEADER, CHAT_RELAY_ENABLED} from '#/lib/constants'
+import {useAgent, useSession} from '#/state/session'
+import {IS_NATIVE} from '#/env'
+
+export const CHAT_RELAY_REDIRECT_URI = 'community.blacksky:/messages/settings'
+
+export type ChatRelayPreference = {
+  push: boolean
+  include: 'all' | 'follows'
+}
+
+export type ChatRelayPreferences = {
+  chat: ChatRelayPreference
+  chatRequest: ChatRelayPreference
+}
+
+export type ChatRelayPreferencesPatch = {
+  chat?: Partial<ChatRelayPreference>
+  chatRequest?: Partial<ChatRelayPreference>
+}
+
+export type ChatRelayEnrollmentInput = {
+  did: string
+  handle: string
+}
+
+export type ChatRelayAccountInput = {
+  did: string
+}
+
+export type ChatRelayPreferencesInput = ChatRelayAccountInput & {
+  patch: ChatRelayPreferencesPatch
+}
+
+export type ChatRelayStatus = {
+  did: string
+  generation?: string
+  status: 'active' | 'disconnected' | 'reauth_required'
+  preferences: ChatRelayPreferences
+}
+
+type EnrollmentResponse = {
+  authorizationUrl: string
+}
+
+const CHAT_RELAY_QUERY = 'chat-relay'
+
+export function chatRelayReturnTo() {
+  if (IS_NATIVE) return CHAT_RELAY_REDIRECT_URI
+  const origin =
+    typeof window !== 'undefined' ? window.location?.origin : undefined
+  if (origin) {
+    return `${origin}/messages/settings`
+  }
+  return undefined
+}
+
+export function chatRelayQueryKey(did?: string) {
+  return [CHAT_RELAY_QUERY, did]
+}
+
+async function readJson<T>(response: Response): Promise<T> {
+  if (!response.ok) {
+    const detail = __DEV__ ? await response.text().catch(() => '') : ''
+    throw new Error(
+      `Chat relay request failed (${response.status})${detail ? `: ${detail}` : ''}`,
+    )
+  }
+  return (await response.json()) as T
+}
+
+async function getStatus(
+  agent: ReturnType<typeof useAgent>,
+  expectedDid: string,
+) {
+  const status = await readJson<ChatRelayStatus | null>(
+    await communityXrpc(
+      agent,
+      'community.blacksky.courier.getEnrollmentStatus',
+      {
+        proxyHeader: CHAT_NOTIF_PROXY_HEADER,
+      },
+    ),
+  )
+  if (!status) return status
+  if (status.did !== expectedDid) {
+    throw new Error('Chat relay account did not match the signed-in account')
+  }
+  if (status.status !== 'active') return status
+  const preferences = await readJson<{preferences: ChatRelayPreferences}>(
+    await communityXrpc(agent, 'chat.bsky.notification.getPreferences', {
+      proxyHeader: CHAT_NOTIF_PROXY_HEADER,
+    }),
+  )
+  return {...status, preferences: preferences.preferences}
+}
+
+export function useChatRelayStatusQuery() {
+  const agent = useAgent()
+  const {currentAccount} = useSession()
+  const did = currentAccount?.did
+
+  return useQuery({
+    queryKey: chatRelayQueryKey(did),
+    queryFn: () => getStatus(agent, did!),
+    enabled: CHAT_RELAY_ENABLED && !!did,
+    refetchOnMount: 'always',
+    refetchOnWindowFocus: true,
+  })
+}
+
+export function useChatRelayEnrollmentMutation() {
+  const agent = useAgent()
+  const queryClient = useQueryClient()
+
+  return useMutation({
+    mutationFn: async ({did, handle}: ChatRelayEnrollmentInput) => {
+      const returnTo = chatRelayReturnTo()
+      const response = await communityXrpc(
+        agent,
+        'community.blacksky.courier.startEnrollment',
+        {
+          body: {
+            handle,
+            ...(returnTo ? {returnTo} : {}),
+          },
+          proxyHeader: CHAT_NOTIF_PROXY_HEADER,
+        },
+      )
+      const data = await readJson<EnrollmentResponse>(response)
+      const authorizationUrl = data.authorizationUrl
+
+      if (IS_NATIVE) {
+        const result = await openAuthSessionAsync(
+          authorizationUrl,
+          CHAT_RELAY_REDIRECT_URI,
+        )
+        const resultType = String(result.type)
+        if (resultType !== 'success') {
+          return {did, completed: false}
+        }
+      } else {
+        window.location.assign(authorizationUrl)
+      }
+      return {did, completed: true}
+    },
+    onSuccess: result => {
+      void queryClient.invalidateQueries({
+        queryKey: chatRelayQueryKey(result.did),
+      })
+    },
+  })
+}
+
+export function useChatRelayDisconnectMutation() {
+  const agent = useAgent()
+  const queryClient = useQueryClient()
+
+  return useMutation({
+    mutationFn: async ({did}: ChatRelayAccountInput) => {
+      await readJson<{ok: true}>(
+        await communityXrpc(agent, 'community.blacksky.courier.disconnect', {
+          body: {},
+          proxyHeader: CHAT_NOTIF_PROXY_HEADER,
+        }),
+      )
+      return {did}
+    },
+    onSuccess: result => {
+      void queryClient.invalidateQueries({
+        queryKey: chatRelayQueryKey(result.did),
+      })
+    },
+  })
+}
+
+export function useChatRelayPreferencesMutation() {
+  const agent = useAgent()
+  const queryClient = useQueryClient()
+
+  return useMutation({
+    mutationFn: async ({did, patch}: ChatRelayPreferencesInput) => {
+      const response = await communityXrpc(
+        agent,
+        'chat.bsky.notification.putPreferences',
+        {body: patch, proxyHeader: CHAT_NOTIF_PROXY_HEADER},
+      )
+      const result = await readJson<{preferences: ChatRelayPreferences}>(
+        response,
+      )
+      return {did, preferences: result.preferences}
+    },
+    onSuccess: result => {
+      queryClient.setQueryData(
+        chatRelayQueryKey(result.did),
+        (old?: ChatRelayStatus | null) =>
+          old ? {...old, preferences: result.preferences} : old,
+      )
+    },
+  })
+}


### PR DESCRIPTION
## Summary

Add feature-gated chat notification enrollment and preference controls.

## Test plan

- [ ] Validate enrollment and return flow on web and native clients
- [ ] Validate preference updates and reconnect behavior
- [ ] Validate notification navigation from a delivered chat alert