### PR TITLE
fix(signup): ignore captcha callbacks in embedded app

### DIFF
--- a/src/App.web.tsx
+++ b/src/App.web.tsx
@@ -91,6 +91,8 @@ void prefetchLiveEvents()
 void prefetchAppConfig()
 
 function hasOAuthCallbackParams(): boolean {
+  if (window.parent !== window) return false
+
   const hash = new URLSearchParams(window.location.hash.slice(1))
   const query = new URLSearchParams(window.location.search)
   const params = hash.has('state') ? hash : query


### PR DESCRIPTION
## Summary
- prevent the web app from treating captcha iframe redirects as OAuth callbacks
- keep top-level OAuth callback handling unchanged
- add regression coverage and bump the app patch version

## Verification
- `./node_modules/.bin/jest src/lib/web/oauth-callback.test.ts --runInBand --forceExit --watchman=false`
- `./node_modules/.bin/eslint src/App.web.tsx src/lib/web/oauth-callback.ts src/lib/web/oauth-callback.test.ts`
- `./node_modules/.bin/tsgo --project ./tsconfig.check.json --pretty false`

No mobile captcha behavior is changed.