### PR TITLE
fix(trending): hide topics for other brands

### DIFF
--- a/src/lib/community/BrandContext.tsx
+++ b/src/lib/community/BrandContext.tsx
@@ -253,6 +253,10 @@ export function useBrand(): ComputedBrandConfig {
   return useContext(BrandContext)
 }
 
+export function isBlackskyBrand(config: ComputedBrandConfig): boolean {
+  return config.metadata.slug === BLACKSKY_CONFIG.metadata.slug
+}
+
 /**
  * Setter for the active brand config. Used by useCommunityBrandSync (native) to
  * re-theme when the active account resolves to a different community. The value

--- a/src/lib/community/__tests__/BrandContext.test.ts
+++ b/src/lib/community/__tests__/BrandContext.test.ts
@@ -5,6 +5,7 @@ import {
   BRAND_DOMAIN,
   DEFAULT_BRAND_CONFIG,
   ensureFollowingPinned,
+  isBlackskyBrand,
 } from '../BrandContext'
 
 describe('BrandContext defaults', () => {
@@ -75,6 +76,19 @@ describe('BrandContext defaults', () => {
     })
     expect(DEFAULT_BRAND_CONFIG.theme.css.selectionLight).toBe('#D2FC51')
     expect(DEFAULT_BRAND_CONFIG.theme.css.selectionDark).toBe('#464985')
+  })
+
+  it('identifies only the Blacksky brand', () => {
+    expect(isBlackskyBrand(DEFAULT_BRAND_CONFIG)).toBe(true)
+    expect(
+      isBlackskyBrand({
+        ...DEFAULT_BRAND_CONFIG,
+        metadata: {
+          ...DEFAULT_BRAND_CONFIG.metadata,
+          slug: 'medsky',
+        },
+      }),
+    ).toBe(false)
   })
 })
 

--- a/src/state/service-config.tsx
+++ b/src/state/service-config.tsx
@@ -1,5 +1,6 @@
 import {createContext, useContext, useMemo} from 'react'
 
+import {isBlackskyBrand, useBrand} from '#/lib/community/BrandContext'
 import {useLanguagePrefs} from '#/state/preferences/languages'
 import {useServiceConfigQuery} from '#/state/queries/service-config'
 import {device} from '#/storage'
@@ -16,9 +17,14 @@ TrendingContext.displayName = 'TrendingContext'
 const CheckEmailConfirmedContext = createContext<boolean | null>(null)
 
 export function Provider({children}: {children: React.ReactNode}) {
+  const brand = useBrand()
   const langPrefs = useLanguagePrefs()
   const {data: config, isLoading: isInitialLoad} = useServiceConfigQuery()
   const trending = useMemo<TrendingContext>(() => {
+    if (!isBlackskyBrand(brand)) {
+      return {enabled: false}
+    }
+
     if (__DEV__) {
       return {enabled: true}
     }
@@ -47,7 +53,7 @@ export function Provider({children}: {children: React.ReactNode}) {
     device.set(['trendingBetaEnabled'], enabled)
 
     return {enabled}
-  }, [isInitialLoad, langPrefs.contentLanguages])
+  }, [brand, isInitialLoad, langPrefs.contentLanguages])
 
   // probably true, so default to true when loading
   // if the call fails, the query will set it to false for us


### PR DESCRIPTION
Restricts trending topics to the Blacksky brand by applying the active brand slug to the existing shared trending gate. Non-Blacksky clients now omit trending surfaces, settings, and their associated queries.