### PR TITLE
feat(release): simple QA release train

### DIFF
--- a/.github/workflows/build-submit-android.yml
+++ b/.github/workflows/build-submit-android.yml
@@ -16,6 +16,10 @@ on:
         type: string
         description: Build profile to use
         required: true
+      submit:
+        type: boolean
+        description: Submit to Google Play (disable to only upload the AAB artifact)
+        default: true
     outputs:
       package-version:
         description: Version from package.json
@@ -122,9 +126,19 @@ jobs:
         run: bash scripts/setGitHubOutput.sh
 
       - name: 🚀 Submit to Google Play
+        if: ${{ inputs.submit != false }}
         env:
           PROFILE: ${{ inputs.profile || 'testflight-android' }}
         run: pnpm eas submit -p android --profile $PROFILE --non-interactive --path build.aab
+
+      - name: 📦 Upload release candidate AAB
+        if: ${{ inputs.submit == false }}
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: release-candidate-android
+          path: build.aab
+          retention-days: 7
+          if-no-files-found: error
 
       - name: 🔧 Setup bundletool
         uses: amyu/setup-bundletool@cc2e1857284660bd625e43f2c8a45626f034302f # v1.1

--- a/.github/workflows/build-submit-ios.yml
+++ b/.github/workflows/build-submit-ios.yml
@@ -24,6 +24,10 @@ on:
         type: boolean
         description: Assign the build to the "QA Team" TestFlight group after submitting
         default: false
+      submit:
+        type: boolean
+        description: Submit to App Store Connect (disable to only upload the IPA artifact)
+        default: true
     outputs:
       package-version:
         description: Version from package.json
@@ -189,7 +193,17 @@ jobs:
           fi
 
       - name: 🚀 Deploy
+        if: ${{ inputs.submit != false }}
         run: pnpm eas submit -p ios --non-interactive --path "$IPA_PATH"
+
+      - name: 📦 Upload release candidate IPA
+        if: ${{ inputs.submit == false }}
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: release-candidate-ios
+          path: ${{ env.IPA_PATH }}
+          retention-days: 7
+          if-no-files-found: error
 
       - name: 🪲 Upload dSYM to Sentry
         run: >

--- a/.github/workflows/bundle-deploy-eas-update.yml
+++ b/.github/workflows/bundle-deploy-eas-update.yml
@@ -2,6 +2,8 @@
 name: Bundle and Deploy EAS Update
 
 on:
+  push:
+    branches: ['release/**']
   workflow_dispatch:
     inputs:
       channel:

--- a/.github/workflows/release-cut.yml
+++ b/.github/workflows/release-cut.yml
@@ -1,0 +1,35 @@
+---
+name: Cut QA release branch
+
+on:
+  workflow_dispatch:
+    inputs:
+      sha:
+        description: Full commit SHA on main to release
+        type: string
+        required: true
+
+permissions:
+  contents: write
+  actions: write
+
+jobs:
+  cut:
+    if: github.repository == 'blacksky-algorithms/blacksky.community'
+    runs-on: ubuntu-latest
+    env:
+      GH_TOKEN: ${{ github.token }}
+      INPUT_SHA: ${{ inputs.sha }}
+    steps:
+      - name: Create release branch and start the QA publish
+        run: |
+          [[ "$INPUT_SHA" =~ ^[a-f0-9]{40}$ ]]
+          status="$(gh api "repos/$GITHUB_REPOSITORY/compare/$INPUT_SHA...main" --jq .status)"
+          if [ "$status" != "ahead" ] && [ "$status" != "identical" ]; then
+            echo "Selected SHA must be a commit on main"
+            exit 1
+          fi
+          branch="release/$(TZ=America/New_York date +%Y-%m-%d)"
+          gh api "repos/$GITHUB_REPOSITORY/git/refs" -f ref="refs/heads/$branch" -f sha="$INPUT_SHA"
+          gh workflow run bundle-deploy-eas-update.yml --ref "$branch"
+          echo "Cut \`$branch\` at \`$INPUT_SHA\` and started the QA OTA publish." >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/release-promote.yml
+++ b/.github/workflows/release-promote.yml
@@ -1,0 +1,102 @@
+---
+name: Promote release to production
+
+on:
+  workflow_dispatch:
+    inputs:
+      notes:
+        description: Release description for the App Store and Play Store
+        type: string
+        required: true
+
+permissions:
+  contents: write
+  actions: write
+
+jobs:
+  ios:
+    if: github.repository == 'blacksky-algorithms/blacksky.community' && startsWith(github.ref, 'refs/heads/release/')
+    uses: ./.github/workflows/build-submit-ios.yml
+    secrets: inherit
+    with:
+      profile: production
+      submit: false
+
+  android:
+    if: github.repository == 'blacksky-algorithms/blacksky.community' && startsWith(github.ref, 'refs/heads/release/')
+    permissions:
+      contents: write
+    uses: ./.github/workflows/build-submit-android.yml
+    secrets: inherit
+    with:
+      profile: production
+      submit: false
+
+  publish:
+    name: Release to stores and production OTA
+    needs: [ios, android]
+    runs-on: macos-26
+    timeout-minutes: 120
+    concurrency:
+      group: release-promote
+      cancel-in-progress: false
+    env:
+      GH_TOKEN: ${{ github.token }}
+      RELEASE_NOTES: ${{ inputs.notes }}
+      APP_VERSION: ${{ needs.ios.outputs.package-version }}
+      IOS_BUILD_NUMBER: ${{ needs.ios.outputs.build-number }}
+      ANDROID_VERSION_CODE: ${{ needs.android.outputs.version-code }}
+    steps:
+      - name: ⬇️ Checkout
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
+
+      - name: ⬇️ Download release candidates
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
+        with:
+          pattern: release-candidate-*
+          merge-multiple: true
+
+      - name: 🚀 Release to the App Store and Play Store
+        env:
+          ASC_KEY_ID: ${{ secrets.ASC_KEY_ID }}
+          ASC_ISSUER_ID: ${{ secrets.ASC_ISSUER_ID }}
+          ASC_KEY_P8_BASE64: ${{ secrets.ASC_KEY_P8_BASE64 }}
+          GPLAY_SERVICE_ACCOUNT_JSON: ${{ secrets.GPLAY_SERVICE_ACCOUNT_JSON }}
+        run: |
+          trap 'rm -f asc_api_key.json' EXIT
+          key_content="$(echo "$ASC_KEY_P8_BASE64" | base64 --decode)"
+          jq -n \
+            --arg key_id "$ASC_KEY_ID" \
+            --arg issuer_id "$ASC_ISSUER_ID" \
+            --arg key "$key_content" \
+            '{key_id: $key_id, issuer_id: $issuer_id, key: $key, in_house: false}' \
+            > asc_api_key.json
+          ipa_path="$(find . -maxdepth 1 -name '*.ipa' -print -quit)"
+          test -n "$ipa_path"
+          test -f build.aab
+          export ASC_API_KEY_PATH="$PWD/asc_api_key.json"
+          export IPA_PATH="$PWD/${ipa_path#./}"
+          export AAB_PATH="$PWD/build.aab"
+          fastlane release_stores
+
+      - name: 🚀 Publish production OTA for the tested JS
+        run: >
+          gh workflow run bundle-deploy-eas-update.yml
+          --ref "$GITHUB_REF_NAME"
+          -f channel=production
+          -f runtimeVersion="$APP_VERSION"
+
+      - name: 📝 Record GitHub release
+        run: |
+          gh release create "v$APP_VERSION" \
+            --target "$GITHUB_SHA" \
+            --title "v$APP_VERSION" \
+            --notes "$RELEASE_NOTES"
+          {
+            echo "Released \`v$APP_VERSION\` from \`$GITHUB_REF_NAME\` at \`$GITHUB_SHA\`."
+            echo "iOS build $IOS_BUILD_NUMBER submitted for App Store review (auto-release)."
+            echo "Android version code $ANDROID_VERSION_CODE released to Play production."
+            echo "Production OTA publish dispatched for runtime $APP_VERSION."
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -1,0 +1,31 @@
+# QA release process
+
+## Cut
+
+Run the **Cut QA release branch** workflow with a full commit SHA from main. It creates
+`release/YYYY-MM-DD` and starts a QA publish: an OTA update to the `testflight` channel, or
+TestFlight / Play internal builds automatically when native code changed since the last build.
+
+## QA
+
+Existing TestFlight and Play internal installs (the `testflight` update channel) receive the
+candidate. Merge fixes into the release branch; every push publishes a fresh QA OTA update
+automatically. Cherry-pick fixes back to main through normal review.
+
+## Promote
+
+Run the **Promote release to production** workflow *on the release branch* and paste the release
+description. It builds production binaries from the branch head, submits iOS for App Store review
+with automatic release, releases Android to Play production, publishes the same JS to the
+`production` OTA channel, and records a GitHub release (`v<version>`) with your notes.
+
+App review timing is Apple's; the Play release and OTA update go live immediately. Delete the
+release branch whenever the train is done.
+
+## Notes
+
+- Bump `package.json` version on main before cutting when a release should be a new store version;
+  build numbers auto-increment via EAS.
+- Play Store descriptions are limited to 500 characters.
+- One-time setup: `GPLAY_SERVICE_ACCOUNT_JSON` repository secret (the Play service-account key
+  already used by EAS submit). All other credentials are the existing build secrets.

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -1,0 +1,33 @@
+lane :release_stores do
+  notes = ENV.fetch('RELEASE_NOTES')
+  version = ENV.fetch('APP_VERSION')
+  deliver(
+    api_key_path: ENV.fetch('ASC_API_KEY_PATH'),
+    app_identifier: 'community.blacksky.app',
+    ipa: ENV.fetch('IPA_PATH'),
+    app_version: version,
+    submit_for_review: true,
+    automatic_release: true,
+    release_notes: {'default' => notes},
+    force: true,
+    skip_screenshots: true,
+    run_precheck_before_submit: false,
+    precheck_include_in_app_purchases: false,
+    submission_information: {add_id_info_uses_idfa: false}
+  )
+  changelog_dir = File.expand_path('metadata/android/en-US/changelogs', __dir__)
+  FileUtils.mkdir_p(changelog_dir)
+  File.write(File.join(changelog_dir, 'default.txt'), notes)
+  upload_to_play_store(
+    json_key_data: ENV.fetch('GPLAY_SERVICE_ACCOUNT_JSON'),
+    package_name: 'community.blacksky.app',
+    aab: ENV.fetch('AAB_PATH'),
+    track: 'production',
+    release_status: 'completed',
+    metadata_path: File.expand_path('metadata/android', __dir__),
+    skip_upload_metadata: true,
+    skip_upload_changelogs: false,
+    skip_upload_images: true,
+    skip_upload_screenshots: true
+  )
+end


### PR DESCRIPTION
Adds a minimal QA release process built on the existing workflows: a cut workflow creates a release/YYYY-MM-DD branch from a chosen main commit and starts a QA publish; every push to a release branch automatically publishes an OTA update to the testflight channel (with the existing native-build fallback when native code changed); a promote workflow builds production binaries from the branch head, submits iOS for App Store review with automatic release, releases Android to Play production with the provided release description, publishes the same JS to the production OTA channel, and records a GitHub release.

Reuses bundle-deploy-eas-update and the reusable build-submit workflows (new optional submit input that uploads the binary as an artifact instead of submitting). New surface: release-cut.yml, release-promote.yml, a small Fastfile, and docs/release-process.md.

One-time setup: GPLAY_SERVICE_ACCOUNT_JSON repository secret. First train should be a supervised rehearsal; the store-release lane is syntax-checked but unexercised against the live stores.

Replaces #186.

Validation: YAML parse and ruby -c pass locally; workflow logic exercised only via review.